### PR TITLE
Use reduced file list when appending to current search string

### DIFF
--- a/src/main/kotlin/com/mituuz/fuzzier/Fuzzier.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/Fuzzier.kt
@@ -167,22 +167,20 @@ class Fuzzier : AnAction() {
 
     private fun processCache(contentIterator: ContentIterator) {
         filePathCache = ArrayList(filePathCacheTemp)
-        filePathCacheTemp = ArrayList()
+        filePathCacheTemp.clear()
         for (virtualFile in filePathCache) {
-            // Tmp cache needs to be filled here | So it needs to empty before this
             contentIterator.processFile(virtualFile)
         }
     }
 
     private fun processIndex(project: Project, contentIterator: ContentIterator) {
-        filePathCacheTemp = ArrayList()
+        filePathCacheTemp.clear()
         val projectFileIndex = ProjectFileIndex.getInstance(project)
         projectFileIndex.iterateContent(contentIterator)
     }
 
     fun getContentIterator(projectBasePath: String, searchString: String, listModel: DefaultListModel<FuzzyMatchContainer>): ContentIterator {
        return ContentIterator { file: VirtualFile ->
-           println(file.path)
            if (!file.isDirectory) {
                val filePath = projectBasePath.let { it1 -> file.path.removePrefix(it1) }
                if (isExcluded(filePath)) {

--- a/src/main/kotlin/com/mituuz/fuzzier/Fuzzier.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/Fuzzier.kt
@@ -26,7 +26,6 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.openapi.wm.WindowManager
 import com.mituuz.fuzzier.settings.FuzzierSettingsService
-import kotlinx.html.currentTimeMillis
 import org.apache.commons.lang3.StringUtils
 import java.awt.event.*
 import javax.swing.*
@@ -39,7 +38,7 @@ class Fuzzier : AnAction() {
     private lateinit var originalDownHandler: EditorActionHandler
     private lateinit var originalUpHandler: EditorActionHandler
     private var fuzzierSettingsService = service<FuzzierSettingsService>()
-    var previousSearchString: String = ""
+    private var previousSearchString: String = ""
     private var filePathCache = ArrayList<VirtualFile>()
     var usedCache: Boolean = false
 
@@ -155,10 +154,6 @@ class Fuzzier : AnAction() {
     fun processFiles(searchString: String, project: Project, projectBasePath: String,
                      listModel: DefaultListModel<FuzzyMatchContainer>) {
         val contentIterator = getContentIterator(projectBasePath, searchString, listModel)
-        val compare = searchString.substring(0, searchString.length - 1)
-        println("searchString: $searchString, previousSearchString: $previousSearchString, compare: $compare")
-
-        val startTime = currentTimeMillis()
         if (searchString.substring(0, searchString.length - 1) == previousSearchString
             && previousSearchString != "") {
             usedCache = true
@@ -168,33 +163,19 @@ class Fuzzier : AnAction() {
             processIndex(project, contentIterator)
         }
         previousSearchString = searchString
-        val endTime = currentTimeMillis()
-        val totalTime = endTime - startTime
-        println("Processed files in: $totalTime ms")
     }
 
     private fun processCache(contentIterator: ContentIterator) {
         filePathCache = ArrayList(filePathCacheTemp)
-
-        // Empty cache
         filePathCacheTemp = ArrayList()
-        var i = 0
-
         for (virtualFile in filePathCache) {
             // Tmp cache needs to be filled here | So it needs to empty before this
             contentIterator.processFile(virtualFile)
-            i++
         }
-
-        println("Processed $i cached files")
     }
 
     private fun processIndex(project: Project, contentIterator: ContentIterator) {
-        println("Process project files")
-        // Empty cache before filling it again
         filePathCacheTemp = ArrayList()
-
-        // Process project files, fill cache
         val projectFileIndex = ProjectFileIndex.getInstance(project)
         projectFileIndex.iterateContent(contentIterator)
     }

--- a/src/test/kotlin/com/mituuz/fuzzier/CacheTest.kt
+++ b/src/test/kotlin/com/mituuz/fuzzier/CacheTest.kt
@@ -1,14 +1,10 @@
 package com.mituuz.fuzzier
 
 import com.intellij.openapi.components.service
-import com.intellij.openapi.project.DumbService
-import com.intellij.psi.PsiDocumentManager
-import com.intellij.testFramework.PsiTestUtil
 import com.intellij.testFramework.TestApplicationManager
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
 import com.intellij.testFramework.fixtures.IdeaProjectTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
-import com.intellij.testFramework.runInEdtAndWait
 import com.mituuz.fuzzier.settings.FuzzierSettingsService
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
@@ -22,6 +18,7 @@ class CacheTest {
     private lateinit var filePathContainer: DefaultListModel<Fuzzier.FuzzyMatchContainer>
     private lateinit var fixture: IdeaProjectTestFixture
     private lateinit var myFixture: CodeInsightTestFixture
+    private var testUtil = TestUtil()
 
     init {
         testApplicationManager = TestApplicationManager.getInstance()
@@ -47,7 +44,7 @@ class CacheTest {
     @Test
     fun `Basic functionality test for the cache`() {
         val filePaths = listOf("src/main.kt", "src/asd/main.kt", "src/asd/asd.kt", "src/not/asd.kt", "src/nope")
-        addFilesToProject(filePaths, myFixture, fixture)
+        testUtil.addFilesToProject(filePaths, myFixture, fixture)
 
         val projectBasePath = myFixture.findFileInTempDir("src").canonicalPath
         if (projectBasePath != null) {
@@ -76,7 +73,7 @@ class CacheTest {
     @Test
     fun `Test cache reset when changing the search string`() {
         val filePaths = listOf("src/main.kt", "src/asd/main.kt", "src/asd/asd.kt", "src/not/asd.kt", "src/nope")
-        addFilesToProject(filePaths, myFixture, fixture)
+        testUtil.addFilesToProject(filePaths, myFixture, fixture)
 
         val projectBasePath = myFixture.findFileInTempDir("src").canonicalPath
         if (projectBasePath != null) {
@@ -100,7 +97,7 @@ class CacheTest {
     @Test
     fun `Test cache functionality when changing string and no results found`() {
         val filePaths = listOf("src/main.kt", "src/asd/main.kt", "src/asd/asd.kt", "src/not/asd.kt", "src/nope")
-        addFilesToProject(filePaths, myFixture, fixture)
+        testUtil.addFilesToProject(filePaths, myFixture, fixture)
 
         val projectBasePath = myFixture.findFileInTempDir("src").canonicalPath
         if (projectBasePath != null) {
@@ -119,19 +116,5 @@ class CacheTest {
             Assertions.assertEquals(0, fuzzier.filePathCacheTemp.size)
             Assertions.assertFalse(fuzzier.usedCache)
         }
-    }
-
-    private fun addFilesToProject(filesToAdd: List<String>, myFixture: CodeInsightTestFixture, fixture: IdeaProjectTestFixture) {
-        filesToAdd.forEach {
-            myFixture.addFileToProject(it, "")
-        }
-
-        // Add source and wait for indexing
-        val dir = myFixture.findFileInTempDir("src")
-        PsiTestUtil.addSourceRoot(fixture.module, dir)
-        runInEdtAndWait {
-            PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
-        }
-        DumbService.getInstance(fixture.project).waitForSmartMode()
     }
 }

--- a/src/test/kotlin/com/mituuz/fuzzier/CacheTest.kt
+++ b/src/test/kotlin/com/mituuz/fuzzier/CacheTest.kt
@@ -1,0 +1,137 @@
+package com.mituuz.fuzzier
+
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.DumbService
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.testFramework.PsiTestUtil
+import com.intellij.testFramework.TestApplicationManager
+import com.intellij.testFramework.fixtures.CodeInsightTestFixture
+import com.intellij.testFramework.fixtures.IdeaProjectTestFixture
+import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
+import com.intellij.testFramework.runInEdtAndWait
+import com.mituuz.fuzzier.settings.FuzzierSettingsService
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import javax.swing.DefaultListModel
+
+class CacheTest {
+    private var fuzzier: Fuzzier
+    private var testApplicationManager: TestApplicationManager
+    private lateinit var filePathContainer: DefaultListModel<Fuzzier.FuzzyMatchContainer>
+    private lateinit var fixture: IdeaProjectTestFixture
+    private lateinit var myFixture: CodeInsightTestFixture
+
+    init {
+        testApplicationManager = TestApplicationManager.getInstance()
+        fuzzier = Fuzzier()
+    }
+
+    @BeforeEach
+    fun setUp() {
+        service<FuzzierSettingsService>().state.exclusionList = listOf()
+        filePathContainer = DefaultListModel<Fuzzier.FuzzyMatchContainer>()
+        val factory = IdeaTestFixtureFactory.getFixtureFactory()
+        val fixtureBuilder = factory.createLightFixtureBuilder(null, "Test")
+        fixture = fixtureBuilder.fixture
+        myFixture = IdeaTestFixtureFactory.getFixtureFactory().createCodeInsightFixture(fixture)
+        myFixture.setUp()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        myFixture.tearDown()
+    }
+
+    @Test
+    fun `Basic functionality test for the cache`() {
+        val filePaths = listOf("src/main.kt", "src/asd/main.kt", "src/asd/asd.kt", "src/not/asd.kt", "src/nope")
+        addFilesToProject(filePaths, myFixture, fixture)
+
+        val projectBasePath = myFixture.findFileInTempDir("src").canonicalPath
+        if (projectBasePath != null) {
+            var searchString = "a"
+            fuzzier.processFiles(searchString, fixture.project, projectBasePath, filePathContainer)
+            Assertions.assertEquals(4, fuzzier.filePathCacheTemp.size)
+            Assertions.assertFalse(fuzzier.usedCache)
+
+            searchString = "as"
+            fuzzier.processFiles(searchString, fixture.project, projectBasePath, filePathContainer)
+            Assertions.assertEquals(3, fuzzier.filePathCacheTemp.size)
+            Assertions.assertTrue(fuzzier.usedCache)
+
+            searchString = "asd"
+            fuzzier.processFiles(searchString, fixture.project, projectBasePath, filePathContainer)
+            Assertions.assertEquals(3, fuzzier.filePathCacheTemp.size)
+            Assertions.assertTrue(fuzzier.usedCache)
+
+            searchString = "as"
+            fuzzier.processFiles(searchString, fixture.project, projectBasePath, filePathContainer)
+            Assertions.assertEquals(3, fuzzier.filePathCacheTemp.size)
+            Assertions.assertFalse(fuzzier.usedCache)
+        }
+    }
+
+    @Test
+    fun `Test cache reset when changing the search string`() {
+        val filePaths = listOf("src/main.kt", "src/asd/main.kt", "src/asd/asd.kt", "src/not/asd.kt", "src/nope")
+        addFilesToProject(filePaths, myFixture, fixture)
+
+        val projectBasePath = myFixture.findFileInTempDir("src").canonicalPath
+        if (projectBasePath != null) {
+            var searchString = "a"
+            fuzzier.processFiles(searchString, fixture.project, projectBasePath, filePathContainer)
+            Assertions.assertEquals(4, fuzzier.filePathCacheTemp.size)
+            Assertions.assertFalse(fuzzier.usedCache)
+
+            searchString = "as"
+            fuzzier.processFiles(searchString, fixture.project, projectBasePath, filePathContainer)
+            Assertions.assertEquals(3, fuzzier.filePathCacheTemp.size)
+            Assertions.assertTrue(fuzzier.usedCache)
+
+            searchString = "n"
+            fuzzier.processFiles(searchString, fixture.project, projectBasePath, filePathContainer)
+            Assertions.assertEquals(4, fuzzier.filePathCacheTemp.size)
+            Assertions.assertFalse(fuzzier.usedCache)
+        }
+    }
+
+    @Test
+    fun `Test cache functionality when changing string and no results found`() {
+        val filePaths = listOf("src/main.kt", "src/asd/main.kt", "src/asd/asd.kt", "src/not/asd.kt", "src/nope")
+        addFilesToProject(filePaths, myFixture, fixture)
+
+        val projectBasePath = myFixture.findFileInTempDir("src").canonicalPath
+        if (projectBasePath != null) {
+            var searchString = "a"
+            fuzzier.processFiles(searchString, fixture.project, projectBasePath, filePathContainer)
+            Assertions.assertEquals(4, fuzzier.filePathCacheTemp.size)
+            Assertions.assertFalse(fuzzier.usedCache)
+
+            searchString = "as"
+            fuzzier.processFiles(searchString, fixture.project, projectBasePath, filePathContainer)
+            Assertions.assertEquals(3, fuzzier.filePathCacheTemp.size)
+            Assertions.assertTrue(fuzzier.usedCache)
+
+            searchString = "b"
+            fuzzier.processFiles(searchString, fixture.project, projectBasePath, filePathContainer)
+            Assertions.assertEquals(0, fuzzier.filePathCacheTemp.size)
+            Assertions.assertFalse(fuzzier.usedCache)
+        }
+    }
+
+    private fun addFilesToProject(filesToAdd: List<String>, myFixture: CodeInsightTestFixture, fixture: IdeaProjectTestFixture) {
+        filesToAdd.forEach {
+            myFixture.addFileToProject(it, "")
+        }
+
+        // Add source and wait for indexing
+        val dir = myFixture.findFileInTempDir("src")
+        PsiTestUtil.addSourceRoot(fixture.module, dir)
+        runInEdtAndWait {
+            PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
+        }
+        DumbService.getInstance(fixture.project).waitForSmartMode()
+    }
+}

--- a/src/test/kotlin/com/mituuz/fuzzier/CacheTest.kt
+++ b/src/test/kotlin/com/mituuz/fuzzier/CacheTest.kt
@@ -71,35 +71,6 @@ class CacheTest {
     }
 
     @Test
-    fun `Basic functionality test for the cache windows style`() {
-        val filePaths = listOf("src\\main.kt", "src\\asd\\main.kt", "src\\asd\\asd.kt", "src\\not\\asd.kt", "src\\nope")
-        testUtil.addFilesToProject(filePaths, myFixture, fixture)
-
-        val projectBasePath = myFixture.findFileInTempDir("src").canonicalPath
-        if (projectBasePath != null) {
-            var searchString = "a"
-            fuzzier.processFiles(searchString, fixture.project, projectBasePath, filePathContainer)
-            Assertions.assertEquals(4, fuzzier.filePathCacheTemp.size)
-            Assertions.assertFalse(fuzzier.usedCache)
-
-            searchString = "as"
-            fuzzier.processFiles(searchString, fixture.project, projectBasePath, filePathContainer)
-            Assertions.assertEquals(3, fuzzier.filePathCacheTemp.size)
-            Assertions.assertTrue(fuzzier.usedCache)
-
-            searchString = "asd"
-            fuzzier.processFiles(searchString, fixture.project, projectBasePath, filePathContainer)
-            Assertions.assertEquals(3, fuzzier.filePathCacheTemp.size)
-            Assertions.assertTrue(fuzzier.usedCache)
-
-            searchString = "as"
-            fuzzier.processFiles(searchString, fixture.project, projectBasePath, filePathContainer)
-            Assertions.assertEquals(3, fuzzier.filePathCacheTemp.size)
-            Assertions.assertFalse(fuzzier.usedCache)
-        }
-    }
-
-    @Test
     fun `Test cache reset when changing the search string`() {
         val filePaths = listOf("src/main.kt", "src/asd/main.kt", "src/asd/asd.kt", "src/not/asd.kt", "src/nope")
         testUtil.addFilesToProject(filePaths, myFixture, fixture)

--- a/src/test/kotlin/com/mituuz/fuzzier/CacheTest.kt
+++ b/src/test/kotlin/com/mituuz/fuzzier/CacheTest.kt
@@ -71,6 +71,35 @@ class CacheTest {
     }
 
     @Test
+    fun `Basic functionality test for the cache windows style`() {
+        val filePaths = listOf("src\\main.kt", "src\\asd\\main.kt", "src\\asd\\asd.kt", "src\\not\\asd.kt", "src\\nope")
+        testUtil.addFilesToProject(filePaths, myFixture, fixture)
+
+        val projectBasePath = myFixture.findFileInTempDir("src").canonicalPath
+        if (projectBasePath != null) {
+            var searchString = "a"
+            fuzzier.processFiles(searchString, fixture.project, projectBasePath, filePathContainer)
+            Assertions.assertEquals(4, fuzzier.filePathCacheTemp.size)
+            Assertions.assertFalse(fuzzier.usedCache)
+
+            searchString = "as"
+            fuzzier.processFiles(searchString, fixture.project, projectBasePath, filePathContainer)
+            Assertions.assertEquals(3, fuzzier.filePathCacheTemp.size)
+            Assertions.assertTrue(fuzzier.usedCache)
+
+            searchString = "asd"
+            fuzzier.processFiles(searchString, fixture.project, projectBasePath, filePathContainer)
+            Assertions.assertEquals(3, fuzzier.filePathCacheTemp.size)
+            Assertions.assertTrue(fuzzier.usedCache)
+
+            searchString = "as"
+            fuzzier.processFiles(searchString, fixture.project, projectBasePath, filePathContainer)
+            Assertions.assertEquals(3, fuzzier.filePathCacheTemp.size)
+            Assertions.assertFalse(fuzzier.usedCache)
+        }
+    }
+
+    @Test
     fun `Test cache reset when changing the search string`() {
         val filePaths = listOf("src/main.kt", "src/asd/main.kt", "src/asd/asd.kt", "src/not/asd.kt", "src/nope")
         testUtil.addFilesToProject(filePaths, myFixture, fixture)
@@ -116,5 +145,23 @@ class CacheTest {
             Assertions.assertEquals(0, fuzzier.filePathCacheTemp.size)
             Assertions.assertFalse(fuzzier.usedCache)
         }
+    }
+
+    @Test
+    fun `Test cache functionality when no files present`() {
+        var searchString = "a"
+        fuzzier.processFiles(searchString, fixture.project, "/", filePathContainer)
+        Assertions.assertEquals(0, fuzzier.filePathCacheTemp.size)
+        Assertions.assertFalse(fuzzier.usedCache)
+
+        searchString = "as"
+        fuzzier.processFiles(searchString, fixture.project, "/", filePathContainer)
+        Assertions.assertEquals(0, fuzzier.filePathCacheTemp.size)
+        Assertions.assertTrue(fuzzier.usedCache)
+
+        searchString = "b"
+        fuzzier.processFiles(searchString, fixture.project, "/", filePathContainer)
+        Assertions.assertEquals(0, fuzzier.filePathCacheTemp.size)
+        Assertions.assertFalse(fuzzier.usedCache)
     }
 }

--- a/src/test/kotlin/com/mituuz/fuzzier/ExcludeTest.kt
+++ b/src/test/kotlin/com/mituuz/fuzzier/ExcludeTest.kt
@@ -18,6 +18,7 @@ import javax.swing.DefaultListModel
 class ExcludeTest {
     private var fuzzier: Fuzzier
     private var testApplicationManager: TestApplicationManager
+    private var testUtil = TestUtil()
 
     init {
         testApplicationManager = TestApplicationManager.getInstance()
@@ -81,7 +82,7 @@ class ExcludeTest {
         val myFixture = IdeaTestFixtureFactory.getFixtureFactory().createCodeInsightFixture(fixture)
 
         myFixture.setUp()
-        addFilesToProject(filesToAdd, myFixture, fixture)
+        testUtil.addFilesToProject(filesToAdd, myFixture, fixture)
 
         val basePath = myFixture.findFileInTempDir("src").canonicalPath
         val contentIterator = basePath?.let { fuzzier.getContentIterator(it, "", filePathContainer) }
@@ -95,19 +96,5 @@ class ExcludeTest {
         myFixture.tearDown()
 
         return filePathContainer
-    }
-
-    private fun addFilesToProject(filesToAdd: List<String>, myFixture: CodeInsightTestFixture, fixture: IdeaProjectTestFixture) {
-        filesToAdd.forEach {
-            myFixture.addFileToProject(it, "")
-        }
-
-        // Add source and wait for indexing
-        val dir = myFixture.findFileInTempDir("src")
-        PsiTestUtil.addSourceRoot(fixture.module, dir)
-        runInEdtAndWait {
-            PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
-        }
-        DumbService.getInstance(fixture.project).waitForSmartMode()
     }
 }

--- a/src/test/kotlin/com/mituuz/fuzzier/ExcludeTest.kt
+++ b/src/test/kotlin/com/mituuz/fuzzier/ExcludeTest.kt
@@ -1,0 +1,113 @@
+package com.mituuz.fuzzier
+
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.roots.ProjectFileIndex
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.testFramework.PsiTestUtil
+import com.intellij.testFramework.TestApplicationManager
+import com.intellij.testFramework.fixtures.CodeInsightTestFixture
+import com.intellij.testFramework.fixtures.IdeaProjectTestFixture
+import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
+import com.intellij.testFramework.runInEdtAndWait
+import com.mituuz.fuzzier.settings.FuzzierSettingsService
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import javax.swing.DefaultListModel
+
+class ExcludeTest {
+    private var fuzzier: Fuzzier
+    private var testApplicationManager: TestApplicationManager
+
+    init {
+        testApplicationManager = TestApplicationManager.getInstance()
+        fuzzier = Fuzzier()
+    }
+
+    @Test
+    fun excludeListTest() {
+        service<FuzzierSettingsService>().state.exclusionList = listOf("asd", "nope")
+        val filePaths = listOf("src/main.kt", "src/asd/main.kt", "src/asd/asd.kt", "src/not/asd.kt", "src/nope")
+        val filePathContainer = setUpProjectFileIndex(filePaths)
+        Assertions.assertEquals(1, filePathContainer.size())
+        Assertions.assertEquals("/main.kt", filePathContainer.get(0).string)
+    }
+
+    @Test
+    fun excludeListTestNoMatches() {
+        service<FuzzierSettingsService>().state.exclusionList = listOf("asd")
+        val filePaths = listOf("src/main.kt", "src/not.kt", "src/dsa/not.kt")
+        val filePathContainer = setUpProjectFileIndex(filePaths)
+        Assertions.assertEquals(3, filePathContainer.size())
+        Assertions.assertEquals("/main.kt", filePathContainer.get(2).string)
+        Assertions.assertEquals("/not.kt", filePathContainer.get(1).string)
+        Assertions.assertEquals("/dsa/not.kt", filePathContainer.get(0).string)
+    }
+
+    @Test
+    fun excludeListTestEmptyList() {
+        service<FuzzierSettingsService>().state.exclusionList = ArrayList()
+        val filePaths = listOf("src/main.kt", "src/not.kt", "src/dsa/not.kt")
+        val filePathContainer = setUpProjectFileIndex(filePaths)
+        Assertions.assertEquals(3, filePathContainer.size())
+        Assertions.assertEquals("/main.kt", filePathContainer.get(2).string)
+        Assertions.assertEquals("/not.kt", filePathContainer.get(1).string)
+        Assertions.assertEquals("/dsa/not.kt", filePathContainer.get(0).string)
+    }
+
+    @Test
+    fun excludeListTestStartsWith() {
+        service<FuzzierSettingsService>().state.exclusionList = listOf("/asd*")
+        val filePaths = listOf("src/main.kt", "src/asd/main.kt", "src/asd/asd.kt", "src/not/asd.kt")
+        val filePathContainer = setUpProjectFileIndex(filePaths)
+        Assertions.assertEquals(2, filePathContainer.size())
+        Assertions.assertEquals("/not/asd.kt", filePathContainer.get(0).string)
+    }
+
+    @Test
+    fun excludeListTestEndsWith() {
+        service<FuzzierSettingsService>().state.exclusionList = listOf("*.log")
+        val filePaths = listOf("src/main.log", "src/asd/main.log", "src/asd/asd.kt", "src/not/asd.kt", "src/nope")
+        val filePathContainer = setUpProjectFileIndex(filePaths)
+        Assertions.assertEquals(3, filePathContainer.size())
+        Assertions.assertEquals("/asd/asd.kt", filePathContainer.get(0).string)
+    }
+
+    private fun setUpProjectFileIndex(filesToAdd: List<String>) : DefaultListModel<Fuzzier.FuzzyMatchContainer> {
+        val filePathContainer = DefaultListModel<Fuzzier.FuzzyMatchContainer>()
+        val factory = IdeaTestFixtureFactory.getFixtureFactory()
+        val fixtureBuilder = factory.createLightFixtureBuilder(null, "Test")
+        val fixture = fixtureBuilder.fixture
+        val myFixture = IdeaTestFixtureFactory.getFixtureFactory().createCodeInsightFixture(fixture)
+
+        myFixture.setUp()
+        addFilesToProject(filesToAdd, myFixture, fixture)
+
+        val basePath = myFixture.findFileInTempDir("src").canonicalPath
+        val contentIterator = basePath?.let { fuzzier.getContentIterator(it, "", filePathContainer) }
+        val index = ProjectFileIndex.getInstance(fixture.project)
+        runInEdtAndWait {
+            if (contentIterator != null) {
+                index.iterateContent(contentIterator)
+            }
+        }
+        // Handle clearing ProjectFileIndex between tests
+        myFixture.tearDown()
+
+        return filePathContainer
+    }
+
+    private fun addFilesToProject(filesToAdd: List<String>, myFixture: CodeInsightTestFixture, fixture: IdeaProjectTestFixture) {
+        filesToAdd.forEach {
+            myFixture.addFileToProject(it, "")
+        }
+
+        // Add source and wait for indexing
+        val dir = myFixture.findFileInTempDir("src")
+        PsiTestUtil.addSourceRoot(fixture.module, dir)
+        runInEdtAndWait {
+            PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
+        }
+        DumbService.getInstance(fixture.project).waitForSmartMode()
+    }
+}

--- a/src/test/kotlin/com/mituuz/fuzzier/ExcludeTest.kt
+++ b/src/test/kotlin/com/mituuz/fuzzier/ExcludeTest.kt
@@ -1,17 +1,11 @@
 package com.mituuz.fuzzier
 
 import com.intellij.openapi.components.service
-import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.roots.ProjectFileIndex
-import com.intellij.psi.PsiDocumentManager
-import com.intellij.testFramework.PsiTestUtil
 import com.intellij.testFramework.TestApplicationManager
-import com.intellij.testFramework.fixtures.CodeInsightTestFixture
-import com.intellij.testFramework.fixtures.IdeaProjectTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
 import com.intellij.testFramework.runInEdtAndWait
 import com.mituuz.fuzzier.settings.FuzzierSettingsService
-import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import javax.swing.DefaultListModel
@@ -20,18 +14,11 @@ class ExcludeTest {
     private var fuzzier: Fuzzier
     private var testApplicationManager: TestApplicationManager
     private var testUtil = TestUtil()
-    private lateinit var myFixture: CodeInsightTestFixture
 
     init {
         testApplicationManager = TestApplicationManager.getInstance()
         fuzzier = Fuzzier()
     }
-
-    @AfterAll
-    fun tearDown() {
-        myFixture.tearDown()
-    }
-
 
     @Test
     fun excludeListTest() {
@@ -87,7 +74,7 @@ class ExcludeTest {
         val factory = IdeaTestFixtureFactory.getFixtureFactory()
         val fixtureBuilder = factory.createLightFixtureBuilder(null, "Test")
         val fixture = fixtureBuilder.fixture
-        myFixture = IdeaTestFixtureFactory.getFixtureFactory().createCodeInsightFixture(fixture)
+        val myFixture = IdeaTestFixtureFactory.getFixtureFactory().createCodeInsightFixture(fixture)
 
         myFixture.setUp()
         testUtil.addFilesToProject(filesToAdd, myFixture, fixture)

--- a/src/test/kotlin/com/mituuz/fuzzier/ExcludeTest.kt
+++ b/src/test/kotlin/com/mituuz/fuzzier/ExcludeTest.kt
@@ -11,6 +11,7 @@ import com.intellij.testFramework.fixtures.IdeaProjectTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
 import com.intellij.testFramework.runInEdtAndWait
 import com.mituuz.fuzzier.settings.FuzzierSettingsService
+import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import javax.swing.DefaultListModel
@@ -19,11 +20,18 @@ class ExcludeTest {
     private var fuzzier: Fuzzier
     private var testApplicationManager: TestApplicationManager
     private var testUtil = TestUtil()
+    private lateinit var myFixture: CodeInsightTestFixture
 
     init {
         testApplicationManager = TestApplicationManager.getInstance()
         fuzzier = Fuzzier()
     }
+
+    @AfterAll
+    fun tearDown() {
+        myFixture.tearDown()
+    }
+
 
     @Test
     fun excludeListTest() {
@@ -79,7 +87,7 @@ class ExcludeTest {
         val factory = IdeaTestFixtureFactory.getFixtureFactory()
         val fixtureBuilder = factory.createLightFixtureBuilder(null, "Test")
         val fixture = fixtureBuilder.fixture
-        val myFixture = IdeaTestFixtureFactory.getFixtureFactory().createCodeInsightFixture(fixture)
+        myFixture = IdeaTestFixtureFactory.getFixtureFactory().createCodeInsightFixture(fixture)
 
         myFixture.setUp()
         testUtil.addFilesToProject(filesToAdd, myFixture, fixture)

--- a/src/test/kotlin/com/mituuz/fuzzier/FuzzierTest.kt
+++ b/src/test/kotlin/com/mituuz/fuzzier/FuzzierTest.kt
@@ -1,19 +1,8 @@
 package com.mituuz.fuzzier
 
-import com.intellij.openapi.components.service
-import com.intellij.openapi.project.DumbService
-import com.intellij.openapi.roots.ProjectFileIndex
-import com.intellij.psi.PsiDocumentManager
-import com.intellij.testFramework.PsiTestUtil
 import com.intellij.testFramework.TestApplicationManager
-import com.intellij.testFramework.fixtures.CodeInsightTestFixture
-import com.intellij.testFramework.fixtures.IdeaProjectTestFixture
-import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
-import com.intellij.testFramework.runInEdtAndWait
-import com.mituuz.fuzzier.settings.FuzzierSettingsService
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
-import javax.swing.DefaultListModel
 
 class FuzzierTest {
     private var fuzzier: Fuzzier
@@ -22,129 +11,6 @@ class FuzzierTest {
     init {
         testApplicationManager = TestApplicationManager.getInstance()
         fuzzier = Fuzzier()
-    }
-
-    @Test
-    fun cacheTestBase() {
-        val filePathContainer = DefaultListModel<Fuzzier.FuzzyMatchContainer>()
-        val factory = IdeaTestFixtureFactory.getFixtureFactory()
-        val fixtureBuilder = factory.createLightFixtureBuilder(null, "Test")
-        val fixture = fixtureBuilder.fixture
-        val myFixture = IdeaTestFixtureFactory.getFixtureFactory().createCodeInsightFixture(fixture)
-        val filePaths = listOf("src/main.kt", "src/asd/main.kt", "src/asd/asd.kt", "src/not/asd.kt", "src/nope")
-
-        myFixture.setUp()
-        addFilesToProject(filePaths, myFixture, fixture)
-
-        val projectBasePath = myFixture.findFileInTempDir("src").canonicalPath
-        if (projectBasePath != null) {
-            var searchString = "a"
-            fuzzier.processFiles(searchString, fixture.project, projectBasePath, filePathContainer)
-            assertEquals(4, fuzzier.filePathCacheTemp.size)
-            assertFalse(fuzzier.usedCache)
-
-            searchString = "as"
-            fuzzier.processFiles(searchString, fixture.project, projectBasePath, filePathContainer)
-            assertEquals(3, fuzzier.filePathCacheTemp.size)
-            assertTrue(fuzzier.usedCache)
-
-            searchString = "asd"
-            fuzzier.processFiles(searchString, fixture.project, projectBasePath, filePathContainer)
-            assertEquals(3, fuzzier.filePathCacheTemp.size)
-            assertTrue(fuzzier.usedCache)
-
-            searchString = "as"
-            fuzzier.processFiles(searchString, fixture.project, projectBasePath, filePathContainer)
-            assertEquals(3, fuzzier.filePathCacheTemp.size)
-            assertFalse(fuzzier.usedCache)
-        }
-    }
-
-    @Test
-    fun excludeListTest() {
-        service<FuzzierSettingsService>().state.exclusionList = listOf("asd", "nope")
-        val filePaths = listOf("src/main.kt", "src/asd/main.kt", "src/asd/asd.kt", "src/not/asd.kt", "src/nope")
-        val filePathContainer = setUpProjectFileIndex(filePaths)
-        assertEquals(1, filePathContainer.size())
-        assertEquals("/main.kt", filePathContainer.get(0).string)
-    }
-
-    @Test
-    fun excludeListTestNoMatches() {
-        service<FuzzierSettingsService>().state.exclusionList = listOf("asd")
-        val filePaths = listOf("src/main.kt", "src/not.kt", "src/dsa/not.kt")
-        val filePathContainer = setUpProjectFileIndex(filePaths)
-        assertEquals(3, filePathContainer.size())
-        assertEquals("/main.kt", filePathContainer.get(2).string)
-        assertEquals("/not.kt", filePathContainer.get(1).string)
-        assertEquals("/dsa/not.kt", filePathContainer.get(0).string)
-       }
-
-    @Test
-    fun excludeListTestEmptyList() {
-        service<FuzzierSettingsService>().state.exclusionList = ArrayList()
-        val filePaths = listOf("src/main.kt", "src/not.kt", "src/dsa/not.kt")
-        val filePathContainer = setUpProjectFileIndex(filePaths)
-        assertEquals(3, filePathContainer.size())
-        assertEquals("/main.kt", filePathContainer.get(2).string)
-        assertEquals("/not.kt", filePathContainer.get(1).string)
-        assertEquals("/dsa/not.kt", filePathContainer.get(0).string)
-    }
-
-    @Test
-    fun excludeListTestStartsWith() {
-        service<FuzzierSettingsService>().state.exclusionList = listOf("/asd*")
-        val filePaths = listOf("src/main.kt", "src/asd/main.kt", "src/asd/asd.kt", "src/not/asd.kt")
-        val filePathContainer = setUpProjectFileIndex(filePaths)
-        assertEquals(2, filePathContainer.size())
-        assertEquals("/not/asd.kt", filePathContainer.get(0).string)
-    }
-
-    @Test
-    fun excludeListTestEndsWith() {
-        service<FuzzierSettingsService>().state.exclusionList = listOf("*.log")
-        val filePaths = listOf("src/main.log", "src/asd/main.log", "src/asd/asd.kt", "src/not/asd.kt", "src/nope")
-        val filePathContainer = setUpProjectFileIndex(filePaths)
-        assertEquals(3, filePathContainer.size())
-        assertEquals("/asd/asd.kt", filePathContainer.get(0).string)
-    }
-
-    private fun setUpProjectFileIndex(filesToAdd: List<String>) : DefaultListModel<Fuzzier.FuzzyMatchContainer> {
-        val filePathContainer = DefaultListModel<Fuzzier.FuzzyMatchContainer>()
-        val factory = IdeaTestFixtureFactory.getFixtureFactory()
-        val fixtureBuilder = factory.createLightFixtureBuilder(null, "Test")
-        val fixture = fixtureBuilder.fixture
-        val myFixture = IdeaTestFixtureFactory.getFixtureFactory().createCodeInsightFixture(fixture)
-
-        myFixture.setUp()
-        addFilesToProject(filesToAdd, myFixture, fixture)
-
-        val basePath = myFixture.findFileInTempDir("src").canonicalPath
-        val contentIterator = basePath?.let { fuzzier.getContentIterator(it, "", filePathContainer) }
-        val index = ProjectFileIndex.getInstance(fixture.project)
-        runInEdtAndWait {
-            if (contentIterator != null) {
-                index.iterateContent(contentIterator)
-            }
-        }
-        // Handle clearing ProjectFileIndex between tests
-        myFixture.tearDown()
-
-        return filePathContainer
-    }
-
-    private fun addFilesToProject(filesToAdd: List<String>, myFixture: CodeInsightTestFixture, fixture: IdeaProjectTestFixture) {
-        filesToAdd.forEach {
-            myFixture.addFileToProject(it, "")
-        }
-
-        // Add source and wait for indexing
-        val dir = myFixture.findFileInTempDir("src")
-        PsiTestUtil.addSourceRoot(fixture.module, dir)
-        runInEdtAndWait {
-            PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
-        }
-        DumbService.getInstance(fixture.project).waitForSmartMode()
     }
 
     @Test

--- a/src/test/kotlin/com/mituuz/fuzzier/FuzzierTest.kt
+++ b/src/test/kotlin/com/mituuz/fuzzier/FuzzierTest.kt
@@ -25,8 +25,7 @@ class FuzzierTest {
     }
 
     @Test
-    fun cacheTest() {
-        val searchString = "a"
+    fun cacheTestBase() {
         val filePathContainer = DefaultListModel<Fuzzier.FuzzyMatchContainer>()
         val factory = IdeaTestFixtureFactory.getFixtureFactory()
         val fixtureBuilder = factory.createLightFixtureBuilder(null, "Test")
@@ -37,11 +36,27 @@ class FuzzierTest {
         myFixture.setUp()
         addFilesToProject(filePaths, myFixture, fixture)
 
-        val basePath = myFixture.findFileInTempDir("src").canonicalPath
-        val contentIterator = basePath?.let { fuzzier.getContentIterator(it, searchString, filePathContainer) }
+        val projectBasePath = myFixture.findFileInTempDir("src").canonicalPath
+        if (projectBasePath != null) {
+            var searchString = "a"
+            fuzzier.processFiles(searchString, fixture.project, projectBasePath, filePathContainer)
+            assertEquals(4, fuzzier.filePathCacheTemp.size)
+            assertFalse(fuzzier.usedCache)
 
-        if (contentIterator != null) {
-            fuzzier.processFiles(searchString, contentIterator, fixture.project)
+            searchString = "as"
+            fuzzier.processFiles(searchString, fixture.project, projectBasePath, filePathContainer)
+            assertEquals(3, fuzzier.filePathCacheTemp.size)
+            assertTrue(fuzzier.usedCache)
+
+            searchString = "asd"
+            fuzzier.processFiles(searchString, fixture.project, projectBasePath, filePathContainer)
+            assertEquals(3, fuzzier.filePathCacheTemp.size)
+            assertTrue(fuzzier.usedCache)
+
+            searchString = "as"
+            fuzzier.processFiles(searchString, fixture.project, projectBasePath, filePathContainer)
+            assertEquals(3, fuzzier.filePathCacheTemp.size)
+            assertFalse(fuzzier.usedCache)
         }
     }
 

--- a/src/test/kotlin/com/mituuz/fuzzier/TestUtil.kt
+++ b/src/test/kotlin/com/mituuz/fuzzier/TestUtil.kt
@@ -1,0 +1,24 @@
+package com.mituuz.fuzzier
+
+import com.intellij.openapi.project.DumbService
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.testFramework.PsiTestUtil
+import com.intellij.testFramework.fixtures.CodeInsightTestFixture
+import com.intellij.testFramework.fixtures.IdeaProjectTestFixture
+import com.intellij.testFramework.runInEdtAndWait
+
+class TestUtil {
+    fun addFilesToProject(filesToAdd: List<String>, myFixture: CodeInsightTestFixture, fixture: IdeaProjectTestFixture) {
+        filesToAdd.forEach {
+            myFixture.addFileToProject(it, "")
+        }
+
+        // Add source and wait for indexing
+        val dir = myFixture.findFileInTempDir("src")
+        PsiTestUtil.addSourceRoot(fixture.module, dir)
+        runInEdtAndWait {
+            PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
+        }
+        DumbService.getInstance(fixture.project).waitForSmartMode()
+    }
+}


### PR DESCRIPTION
After searching for single character, store the current file and only check that if new search string = old + x

This enables faster search when writing more of the search string