### PR TITLE
Filename rendering options

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.mituuz"
-version = "0.15"
+version = "0.16"
 
 repositories {
   mavenCentral()

--- a/src/main/kotlin/com/mituuz/fuzzier/Fuzzier.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/Fuzzier.kt
@@ -115,7 +115,8 @@ class Fuzzier : FuzzyAction() {
                     override fun getListCellRendererComponent(list: JList<*>?, value: Any?, index: Int, isSelected: Boolean, cellHasFocus: Boolean): Component {
                         val renderer = super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus) as JLabel
                         val container = value as FuzzyMatchContainer
-                        renderer.text = container.toString(FilenameType.FILENAME_WITH_PATH)
+                        val filenameType = fuzzierSettingsService.state.filenameType
+                        renderer.text = container.toString(filenameType)
                         return renderer
                     }
                 }

--- a/src/main/kotlin/com/mituuz/fuzzier/Fuzzier.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/Fuzzier.kt
@@ -111,15 +111,7 @@ class Fuzzier : FuzzyAction() {
 
             SwingUtilities.invokeLater {
                 component.fileList.model = listModel
-                component.fileList.cellRenderer = object : DefaultListCellRenderer() {
-                    override fun getListCellRendererComponent(list: JList<*>?, value: Any?, index: Int, isSelected: Boolean, cellHasFocus: Boolean): Component {
-                        val renderer = super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus) as JLabel
-                        val container = value as FuzzyMatchContainer
-                        val filenameType = fuzzierSettingsService.state.filenameType
-                        renderer.text = container.toString(filenameType)
-                        return renderer
-                    }
-                }
+                component.fileList.cellRenderer = getCellRenderer()
                 component.fileList.setPaintBusy(false)
                 if (!component.fileList.isEmpty) {
                     component.fileList.setSelectedValue(listModel[0], true)

--- a/src/main/kotlin/com/mituuz/fuzzier/Fuzzier.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/Fuzzier.kt
@@ -17,7 +17,6 @@ import com.intellij.openapi.util.DimensionService
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.openapi.wm.WindowManager
-import com.mituuz.fuzzier.StringEvaluator.FilenameType
 import com.mituuz.fuzzier.StringEvaluator.FuzzyMatchContainer
 import com.mituuz.fuzzier.components.FuzzyFinderComponent
 import org.apache.commons.lang3.StringUtils
@@ -107,6 +106,7 @@ class Fuzzier : FuzzyAction() {
                 projectFileIndex.iterateContent(contentIterator)
             }
             val sortedList = listModel.elements().toList().sortedByDescending { it.score }
+            listModel.clear()
             sortedList.forEach { listModel.addElement(it) }
 
             SwingUtilities.invokeLater {

--- a/src/main/kotlin/com/mituuz/fuzzier/FuzzyAction.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/FuzzyAction.kt
@@ -141,6 +141,7 @@ abstract class FuzzyAction : AnAction() {
         }
     }
 
+    // Used for testing
     fun setFiletype(filenameType: FilenameType) {
         fuzzierSettingsService.state.filenameType = filenameType
     }

--- a/src/main/kotlin/com/mituuz/fuzzier/FuzzyMover.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/FuzzyMover.kt
@@ -194,6 +194,7 @@ class FuzzyMover : FuzzyAction() {
                 projectFileIndex.iterateContent(contentIterator)
             }
             val sortedList = listModel.elements().toList().sortedByDescending { it.score }
+            listModel.clear()
             sortedList.forEach { listModel.addElement(it) }
 
             SwingUtilities.invokeLater {

--- a/src/main/kotlin/com/mituuz/fuzzier/FuzzyMover.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/FuzzyMover.kt
@@ -19,8 +19,6 @@ import com.intellij.psi.PsiDirectory
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
 import com.intellij.refactoring.move.moveFilesOrDirectories.MoveFilesOrDirectoriesUtil
-import com.mituuz.fuzzier.StringEvaluator.FilenameType
-import com.mituuz.fuzzier.StringEvaluator.FilenameType.FILENAME_WITH_PATH
 import com.mituuz.fuzzier.StringEvaluator.FuzzyMatchContainer
 import com.mituuz.fuzzier.components.SimpleFinderComponent
 import org.apache.commons.lang3.StringUtils
@@ -204,7 +202,8 @@ class FuzzyMover : FuzzyAction() {
                     override fun getListCellRendererComponent(list: JList<*>?, value: Any?, index: Int, isSelected: Boolean, cellHasFocus: Boolean): Component {
                         val renderer = super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus) as JLabel
                         val container = value as FuzzyMatchContainer
-                        renderer.text = container.toString(FILENAME_WITH_PATH)
+                        val filenameType = fuzzierSettingsService.state.filenameType
+                        renderer.text = container.toString(filenameType)
                         return renderer
                     }
                 }

--- a/src/main/kotlin/com/mituuz/fuzzier/FuzzyMover.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/FuzzyMover.kt
@@ -18,6 +18,7 @@ import com.intellij.openapi.wm.WindowManager
 import com.intellij.psi.PsiDirectory
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
+import com.intellij.psi.codeStyle.extractor.ui.ExtractedSettingsDialog.CellRenderer
 import com.intellij.refactoring.move.moveFilesOrDirectories.MoveFilesOrDirectoriesUtil
 import com.mituuz.fuzzier.StringEvaluator.FilenameType
 import com.mituuz.fuzzier.StringEvaluator.FilenameType.FILEPATH_ONLY
@@ -189,7 +190,7 @@ class FuzzyMover : FuzzyAction() {
             val contentIterator = if (!component.isDirSelector) {
                 projectBasePath?.let { stringEvaluator.getContentIterator(it, searchString, listModel) }
             } else {
-                projectBasePath?.let { stringEvaluator.getDirIterator(it, searchString, listModel ) }
+                projectBasePath?.let { stringEvaluator.getDirIterator(it, searchString, listModel) }
             }
 
             if (contentIterator != null) {
@@ -201,23 +202,34 @@ class FuzzyMover : FuzzyAction() {
 
             SwingUtilities.invokeLater {
                 component.fileList.model = listModel
-                component.fileList.cellRenderer = object : DefaultListCellRenderer() {
-                    override fun getListCellRendererComponent(list: JList<*>?, value: Any?, index: Int, isSelected: Boolean, cellHasFocus: Boolean): Component {
-                        val renderer = super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus) as JLabel
-                        val container = value as FuzzyMatchContainer
-                        val filenameType: FilenameType = if (component.isDirSelector) {
-                            FILEPATH_ONLY // Directories are always shown as full paths
-                        } else {
-                            fuzzierSettingsService.state.filenameType
-                        }
-                        renderer.text = container.toString(filenameType)
-                        return renderer
-                    }
-                }
+                component.fileList.cellRenderer = getCellRenderer()
                 component.fileList.setPaintBusy(false)
                 if (!component.fileList.isEmpty) {
                     component.fileList.setSelectedValue(listModel[0], true)
                 }
+            }
+        }
+    }
+
+    fun getCellRenderer(): ListCellRenderer<Any?> {
+        return object : DefaultListCellRenderer() {
+            override fun getListCellRendererComponent(
+                list: JList<*>?,
+                value: Any?,
+                index: Int,
+                isSelected: Boolean,
+                cellHasFocus: Boolean
+            ): Component {
+                val renderer =
+                    super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus) as JLabel
+                val container = value as FuzzyMatchContainer
+                val filenameType: FilenameType = if (component.isDirSelector) {
+                    FILEPATH_ONLY // Directories are always shown as full paths
+                } else {
+                    fuzzierSettingsService.state.filenameType
+                }
+                renderer.text = container.toString(filenameType)
+                return renderer
             }
         }
     }

--- a/src/main/kotlin/com/mituuz/fuzzier/FuzzyMover.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/FuzzyMover.kt
@@ -18,14 +18,10 @@ import com.intellij.openapi.wm.WindowManager
 import com.intellij.psi.PsiDirectory
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
-import com.intellij.psi.codeStyle.extractor.ui.ExtractedSettingsDialog.CellRenderer
 import com.intellij.refactoring.move.moveFilesOrDirectories.MoveFilesOrDirectoriesUtil
-import com.mituuz.fuzzier.StringEvaluator.FilenameType
-import com.mituuz.fuzzier.StringEvaluator.FilenameType.FILEPATH_ONLY
 import com.mituuz.fuzzier.StringEvaluator.FuzzyMatchContainer
 import com.mituuz.fuzzier.components.SimpleFinderComponent
 import org.apache.commons.lang3.StringUtils
-import java.awt.Component
 import java.awt.event.*
 import java.util.concurrent.CompletableFuture
 import javax.swing.*
@@ -207,29 +203,6 @@ class FuzzyMover : FuzzyAction() {
                 if (!component.fileList.isEmpty) {
                     component.fileList.setSelectedValue(listModel[0], true)
                 }
-            }
-        }
-    }
-
-    fun getCellRenderer(): ListCellRenderer<Any?> {
-        return object : DefaultListCellRenderer() {
-            override fun getListCellRendererComponent(
-                list: JList<*>?,
-                value: Any?,
-                index: Int,
-                isSelected: Boolean,
-                cellHasFocus: Boolean
-            ): Component {
-                val renderer =
-                    super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus) as JLabel
-                val container = value as FuzzyMatchContainer
-                val filenameType: FilenameType = if (component.isDirSelector) {
-                    FILEPATH_ONLY // Directories are always shown as full paths
-                } else {
-                    fuzzierSettingsService.state.filenameType
-                }
-                renderer.text = container.toString(filenameType)
-                return renderer
             }
         }
     }

--- a/src/main/kotlin/com/mituuz/fuzzier/FuzzyMover.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/FuzzyMover.kt
@@ -19,6 +19,8 @@ import com.intellij.psi.PsiDirectory
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
 import com.intellij.refactoring.move.moveFilesOrDirectories.MoveFilesOrDirectoriesUtil
+import com.mituuz.fuzzier.StringEvaluator.FilenameType
+import com.mituuz.fuzzier.StringEvaluator.FilenameType.FILEPATH_ONLY
 import com.mituuz.fuzzier.StringEvaluator.FuzzyMatchContainer
 import com.mituuz.fuzzier.components.SimpleFinderComponent
 import org.apache.commons.lang3.StringUtils
@@ -203,7 +205,12 @@ class FuzzyMover : FuzzyAction() {
                     override fun getListCellRendererComponent(list: JList<*>?, value: Any?, index: Int, isSelected: Boolean, cellHasFocus: Boolean): Component {
                         val renderer = super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus) as JLabel
                         val container = value as FuzzyMatchContainer
-                        val filenameType = fuzzierSettingsService.state.filenameType
+                        val filenameType: FilenameType
+                        filenameType = if (component.isDirSelector) {
+                            FILEPATH_ONLY // Directories are always shown as full paths
+                        } else {
+                            fuzzierSettingsService.state.filenameType
+                        }
                         renderer.text = container.toString(filenameType)
                         return renderer
                     }

--- a/src/main/kotlin/com/mituuz/fuzzier/FuzzyMover.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/FuzzyMover.kt
@@ -112,7 +112,7 @@ class FuzzyMover : FuzzyAction() {
             val virtualFile =
                 VirtualFileManager.getInstance().findFileByUrl("file://$projectBasePath$selectedValue")
             virtualFile?.let {
-                ApplicationManager.getApplication().executeOnPooledThread() {
+                ApplicationManager.getApplication().executeOnPooledThread {
                     ApplicationManager.getApplication().runReadAction {
                         movableFile = PsiManager.getInstance(project).findFile(it)!!
                     }

--- a/src/main/kotlin/com/mituuz/fuzzier/FuzzyMover.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/FuzzyMover.kt
@@ -205,8 +205,7 @@ class FuzzyMover : FuzzyAction() {
                     override fun getListCellRendererComponent(list: JList<*>?, value: Any?, index: Int, isSelected: Boolean, cellHasFocus: Boolean): Component {
                         val renderer = super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus) as JLabel
                         val container = value as FuzzyMatchContainer
-                        val filenameType: FilenameType
-                        filenameType = if (component.isDirSelector) {
+                        val filenameType: FilenameType = if (component.isDirSelector) {
                             FILEPATH_ONLY // Directories are always shown as full paths
                         } else {
                             fuzzierSettingsService.state.filenameType

--- a/src/main/kotlin/com/mituuz/fuzzier/StringEvaluator.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/StringEvaluator.kt
@@ -68,7 +68,8 @@ class StringEvaluator(
 
     fun fuzzyContainsCaseInsensitive(filePath: String, searchString: String): FuzzyMatchContainer? {
         if (searchString.isBlank()) {
-            return FuzzyMatchContainer(0, filePath)
+            val filename = filePath.substring(filePath.lastIndexOf("/") + 1)
+            return FuzzyMatchContainer(0, filePath, filename)
         }
         if (searchString.length > filePath.length) {
             return null
@@ -84,7 +85,8 @@ class StringEvaluator(
         for (s in StringUtils.split(lowerSearchString, " ")) {
             score += processSearchString(s, lowerFilePath) ?: return null
         }
-        return FuzzyMatchContainer(score, filePath)
+        val filename = filePath.substring(filePath.lastIndexOf("/") + 1)
+        return FuzzyMatchContainer(score, filePath, filename)
     }
 
     private fun processSearchString(s: String, lowerFilePath: String): Int? {
@@ -161,7 +163,19 @@ class StringEvaluator(
         return score.toInt()
     }
 
-    data class FuzzyMatchContainer(val score: Int, val string: String)
+    data class FuzzyMatchContainer(val score: Int, val filePath: String, val filename: String) {
+        fun toString(filenameType: FilenameType): String {
+            return when (filenameType) {
+                FilenameType.FILENAME_ONLY -> filename
+                FilenameType.FILEPATH -> filePath
+                FilenameType.FILENAME_WITH_PATH -> "$filename ($filePath)"
+            }
+        }
+    }
+
+    enum class FilenameType {
+        FILENAME_ONLY, FILEPATH, FILENAME_WITH_PATH
+    }
 
     fun setSettings(multiMatch: Boolean, matchWeightSingleChar: Int, matchWeightPartialPath: Int,
                     matchWeightStreakModifier: Int) {

--- a/src/main/kotlin/com/mituuz/fuzzier/StringEvaluator.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/StringEvaluator.kt
@@ -167,14 +167,16 @@ class StringEvaluator(
         fun toString(filenameType: FilenameType): String {
             return when (filenameType) {
                 FilenameType.FILENAME_ONLY -> filename
-                FilenameType.FILEPATH -> filePath
+                FilenameType.FILEPATH_ONLY -> filePath
                 FilenameType.FILENAME_WITH_PATH -> "$filename ($filePath)"
             }
         }
     }
 
-    enum class FilenameType {
-        FILENAME_ONLY, FILEPATH, FILENAME_WITH_PATH
+    enum class FilenameType(val text: String) {
+        FILEPATH_ONLY("Filepath only"),
+        FILENAME_ONLY("Filename only"),
+        FILENAME_WITH_PATH("Filename with (path)")
     }
 
     fun setSettings(multiMatch: Boolean, matchWeightSingleChar: Int, matchWeightPartialPath: Int,

--- a/src/main/kotlin/com/mituuz/fuzzier/components/FuzzierSettingsComponent.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/components/FuzzierSettingsComponent.kt
@@ -127,7 +127,7 @@ class FuzzierSettingsComponent {
         """.trimIndent()
 
         filenameTypeInstructions.toolTipText = """
-            Controls how the filename is shown on the popup.
+            Controls how the filename is shown on the file search and selector popups.
         """.trimIndent()
     }
 }

--- a/src/main/kotlin/com/mituuz/fuzzier/components/FuzzierSettingsComponent.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/components/FuzzierSettingsComponent.kt
@@ -8,9 +8,12 @@ import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBTextArea
 import com.intellij.util.ui.FormBuilder
+import com.intellij.openapi.ui.ComboBox
+import com.mituuz.fuzzier.StringEvaluator.FilenameType
+import com.mituuz.fuzzier.StringEvaluator.FilenameType.*
 import com.mituuz.fuzzier.settings.FuzzierSettingsService
-import javax.swing.JButton
-import javax.swing.JPanel
+import java.awt.Component
+import javax.swing.*
 import javax.swing.border.LineBorder
 
 class FuzzierSettingsComponent {
@@ -21,6 +24,9 @@ class FuzzierSettingsComponent {
     var debounceTimerValue = JBIntSpinner(150, 0, 2000)
     private var debounceInstructions = JBLabel("<html><strong>Debounce period (ms)</strong></html>", AllIcons.General.ContextHelp, JBLabel.LEFT)
     private var resetWindowDimension = JButton("Reset popup location")
+    private var filenameTypeInstructions = JBLabel("<html><strong>Filename type</strong></html>", AllIcons.General.ContextHelp, JBLabel.LEFT)
+    var filenameTypeSelector = ComboBox<FilenameType>()
+
     var multiMatchActive = JBCheckBox()
     private var multiMatchInstructions = JBLabel("<html><strong>Match characters multiple times</strong></html>", AllIcons.General.ContextHelp, JBLabel.LEFT)
     var matchWeightPartialPath = JBIntSpinner(10, 0, 100)
@@ -29,6 +35,7 @@ class FuzzierSettingsComponent {
     private var singleCharInfo = JBLabel("<html><strong>Match weight: Single char (* 0.1)</strong></html>", AllIcons.General.ContextHelp, JBLabel.LEFT)
     var matchWeightStreakModifier = JBIntSpinner(10, 0, 100)
     private var streakModifierInfo = JBLabel("<html><strong>Match weight: Streak modifier (* 0.1)</strong></html>", AllIcons.General.ContextHelp, JBLabel.LEFT)
+
     private var startTestBench = JButton("Launch Test Bench", AllIcons.General.ContextHelp)
     private var testBench = TestBenchComponent()
 
@@ -40,6 +47,8 @@ class FuzzierSettingsComponent {
             .addSeparator()
             .addLabeledComponent("<html><strong>Open files in a new tab</strong></html>", newTabSelect)
             .addLabeledComponent(debounceInstructions, debounceTimerValue)
+            .addLabeledComponent(filenameTypeInstructions, filenameTypeSelector)
+
             .addSeparator()
             .addComponent(JBLabel("<html><strong>Match settings</strong></html>"))
             .addLabeledComponent(multiMatchInstructions, multiMatchActive)
@@ -61,6 +70,19 @@ class FuzzierSettingsComponent {
         resetWindowDimension.addActionListener {
             service<FuzzierSettingsService>().state.resetWindow = true
         }
+
+        filenameTypeSelector.renderer = object : DefaultListCellRenderer() {
+            override fun getListCellRendererComponent(list: JList<*>?, value: Any?, index: Int, isSelected: Boolean, cellHasFocus: Boolean): Component {
+                val renderer = super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus) as JLabel
+                val filenameType = value as FilenameType
+                renderer.text = filenameType.text
+                return renderer
+            }
+        }
+        for (filenameType in entries) {
+            filenameTypeSelector.addItem(filenameType)
+        }
+
         startTestBench.addActionListener {
             startTestBench.isEnabled = false
             testBench.fill(this)
@@ -102,6 +124,10 @@ class FuzzierSettingsComponent {
 
         startTestBench.toolTipText = """
             Test settings changes live on the current project's file index.
+        """.trimIndent()
+
+        filenameTypeInstructions.toolTipText = """
+            Controls how the filename is shown on the popup.
         """.trimIndent()
     }
 }

--- a/src/main/kotlin/com/mituuz/fuzzier/components/FuzzierSettingsComponent.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/components/FuzzierSettingsComponent.kt
@@ -127,7 +127,11 @@ class FuzzierSettingsComponent {
         """.trimIndent()
 
         filenameTypeInstructions.toolTipText = """
-            Controls how the filename is shown on the file search and selector popups.
+            Controls how the filename is shown on the file search and selector popups.<br><br>
+            Choices are as follows (/path/to/file):<br><br>
+            <strong>Full path</strong> - Shows the full path of the file: /path/to/file<br>
+            <strong>Filename only</strong> - Shows only the filename: file<br>
+            <strong>Filename with (path)</strong> - Shows path in brackets: file (/path/to/file)
         """.trimIndent()
     }
 }

--- a/src/main/kotlin/com/mituuz/fuzzier/components/FuzzyComponent.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/components/FuzzyComponent.kt
@@ -2,7 +2,6 @@ package com.mituuz.fuzzier.components
 
 import com.intellij.ui.EditorTextField
 import com.intellij.ui.components.JBList
-import com.mituuz.fuzzier.StringEvaluator
 import com.mituuz.fuzzier.StringEvaluator.FuzzyMatchContainer
 import javax.swing.JPanel
 

--- a/src/main/kotlin/com/mituuz/fuzzier/components/FuzzyComponent.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/components/FuzzyComponent.kt
@@ -2,10 +2,12 @@ package com.mituuz.fuzzier.components
 
 import com.intellij.ui.EditorTextField
 import com.intellij.ui.components.JBList
+import com.mituuz.fuzzier.StringEvaluator
+import com.mituuz.fuzzier.StringEvaluator.FuzzyMatchContainer
 import javax.swing.JPanel
 
 open class FuzzyComponent : JPanel() {
-    var fileList = JBList<String?>()
+    var fileList = JBList<FuzzyMatchContainer?>()
     var searchField = EditorTextField()
     var isDirSelector = false
 }

--- a/src/main/kotlin/com/mituuz/fuzzier/components/FuzzyFinderComponent.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/components/FuzzyFinderComponent.kt
@@ -7,6 +7,7 @@ import com.intellij.ui.components.JBScrollPane
 import com.intellij.uiDesigner.core.GridConstraints
 import com.intellij.uiDesigner.core.GridLayoutManager
 import com.intellij.util.ui.JBUI
+import com.mituuz.fuzzier.StringEvaluator
 import java.awt.BorderLayout
 import java.awt.Dimension
 import javax.swing.JPanel
@@ -92,7 +93,7 @@ class FuzzyFinderComponent(project: Project) : FuzzyComponent() {
                 false
             )
         )
-        fileList = JBList<String?>()
+        fileList = JBList<StringEvaluator.FuzzyMatchContainer?>()
         fileList.selectionMode = 0
         scrollPane1.setViewportView(fileList)
     }

--- a/src/main/kotlin/com/mituuz/fuzzier/components/TestBenchComponent.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/components/TestBenchComponent.kt
@@ -120,7 +120,7 @@ class TestBenchComponent : JPanel() {
             }
             val sortedList = listModel.elements().toList().sortedByDescending { it.score }
             val valModel = DefaultListModel<String>()
-            sortedList.forEach { valModel.addElement("${it.string} (${it.score})") }
+            sortedList.forEach { valModel.addElement("${it.filePath} (${it.score})") }
 
             SwingUtilities.invokeLater {
                 fileList.model = valModel

--- a/src/main/kotlin/com/mituuz/fuzzier/settings/FuzzierSettingsConfigurable.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/settings/FuzzierSettingsConfigurable.kt
@@ -2,6 +2,7 @@ package com.mituuz.fuzzier.settings
 
 import com.intellij.openapi.components.service
 import com.intellij.openapi.options.Configurable
+import com.mituuz.fuzzier.StringEvaluator.FilenameType
 import com.mituuz.fuzzier.components.FuzzierSettingsComponent
 import javax.swing.JComponent
 
@@ -22,6 +23,8 @@ class FuzzierSettingsConfigurable : Configurable {
         fuzzierSettingsComponent.exclusionList.text = combinedString
         fuzzierSettingsComponent.newTabSelect.isSelected = fuzzierSettingsService.state.newTab
         fuzzierSettingsComponent.debounceTimerValue.value = fuzzierSettingsService.state.debouncePeriod
+        fuzzierSettingsComponent.filenameTypeSelector.selectedIndex = fuzzierSettingsService.state.filenameType.ordinal
+
         fuzzierSettingsComponent.multiMatchActive.isSelected = fuzzierSettingsService.state.multiMatch
         fuzzierSettingsComponent.matchWeightPartialPath.value = fuzzierSettingsService.state.matchWeightPartialPath
         fuzzierSettingsComponent.matchWeightSingleChar.value = fuzzierSettingsService.state.matchWeightSingleChar
@@ -34,6 +37,8 @@ class FuzzierSettingsConfigurable : Configurable {
         return fuzzierSettingsService.state.exclusionList != fuzzierSettingsComponent.exclusionList.text.split("\n")
                 || fuzzierSettingsService.state.newTab != fuzzierSettingsComponent.newTabSelect.isSelected
                 || fuzzierSettingsService.state.debouncePeriod != fuzzierSettingsComponent.debounceTimerValue.value
+                || fuzzierSettingsService.state.filenameType != fuzzierSettingsComponent.filenameTypeSelector.selectedItem
+
                 || fuzzierSettingsService.state.multiMatch != fuzzierSettingsComponent.multiMatchActive.isSelected
                 || fuzzierSettingsService.state.matchWeightPartialPath != fuzzierSettingsComponent.matchWeightPartialPath.value
                 || fuzzierSettingsService.state.matchWeightSingleChar != fuzzierSettingsComponent.matchWeightSingleChar.value
@@ -49,6 +54,8 @@ class FuzzierSettingsConfigurable : Configurable {
         fuzzierSettingsService.state.exclusionList = newList
         fuzzierSettingsService.state.newTab = fuzzierSettingsComponent.newTabSelect.isSelected
         fuzzierSettingsService.state.debouncePeriod = fuzzierSettingsComponent.debounceTimerValue.value as Int
+        fuzzierSettingsService.state.filenameType = FilenameType.entries.toTypedArray()[fuzzierSettingsComponent.filenameTypeSelector.selectedIndex]
+        
         fuzzierSettingsService.state.multiMatch = fuzzierSettingsComponent.multiMatchActive.isSelected
         fuzzierSettingsService.state.matchWeightPartialPath = fuzzierSettingsComponent.matchWeightPartialPath.value as Int
         fuzzierSettingsService.state.matchWeightSingleChar = fuzzierSettingsComponent.matchWeightSingleChar.value as Int

--- a/src/main/kotlin/com/mituuz/fuzzier/settings/FuzzierSettingsService.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/settings/FuzzierSettingsService.kt
@@ -3,6 +3,7 @@ package com.mituuz.fuzzier.settings
 import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
+import com.mituuz.fuzzier.StringEvaluator.FilenameType
 
 @State(
     name = "com.mituuz.fuzzier.FuzzierSettings",
@@ -16,6 +17,7 @@ class FuzzierSettingsService : PersistentStateComponent<FuzzierSettingsService.S
         var debouncePeriod: Int = 150
         var resetWindow = false
         var multiMatch = false
+        var filenameType: FilenameType = FilenameType.FILEPATH_ONLY
 
         var matchWeightPartialPath = 10
         var matchWeightSingleChar = 5

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -29,7 +29,13 @@
   </extensions>
 
   <change-notes><![CDATA[
-  Refactor some shared functionality into a separate class, for later
+  <h2>Added an option to select how the list is displayed on the settings page.</h2>
+  For example: /path/to/file
+  <ul>
+    <li>Filepath only: /path/to/file</li>
+    <li>Filename only: file</li>
+    <li>Filename with path: file (/path/to/file)</li>
+  </ul>
   ]]>
   </change-notes>
 

--- a/src/test/kotlin/com/mituuz/fuzzier/ExcludeTest.kt
+++ b/src/test/kotlin/com/mituuz/fuzzier/ExcludeTest.kt
@@ -19,7 +19,7 @@ class ExcludeTest {
         val filePaths = listOf("src/main.kt", "src/asd/main.kt", "src/asd/asd.kt", "src/not/asd.kt", "src/nope")
         val filePathContainer = testUtil.setUpProjectFileIndex(filePaths, listOf("asd", "nope"))
         Assertions.assertEquals(1, filePathContainer.size())
-        Assertions.assertEquals("/main.kt", filePathContainer.get(0).string)
+        Assertions.assertEquals("/main.kt", filePathContainer.get(0).filePath)
     }
 
     @Test
@@ -27,9 +27,9 @@ class ExcludeTest {
         val filePaths = listOf("src/main.kt", "src/not.kt", "src/dsa/not.kt")
         val filePathContainer = testUtil.setUpProjectFileIndex(filePaths, listOf("asd"))
         Assertions.assertEquals(3, filePathContainer.size())
-        Assertions.assertEquals("/main.kt", filePathContainer.get(2).string)
-        Assertions.assertEquals("/not.kt", filePathContainer.get(1).string)
-        Assertions.assertEquals("/dsa/not.kt", filePathContainer.get(0).string)
+        Assertions.assertEquals("/main.kt", filePathContainer.get(2).filePath)
+        Assertions.assertEquals("/not.kt", filePathContainer.get(1).filePath)
+        Assertions.assertEquals("/dsa/not.kt", filePathContainer.get(0).filePath)
     }
 
     @Test
@@ -37,9 +37,9 @@ class ExcludeTest {
         val filePaths = listOf("src/main.kt", "src/not.kt", "src/dsa/not.kt")
         val filePathContainer = testUtil.setUpProjectFileIndex(filePaths, ArrayList())
         Assertions.assertEquals(3, filePathContainer.size())
-        Assertions.assertEquals("/main.kt", filePathContainer.get(2).string)
-        Assertions.assertEquals("/not.kt", filePathContainer.get(1).string)
-        Assertions.assertEquals("/dsa/not.kt", filePathContainer.get(0).string)
+        Assertions.assertEquals("/main.kt", filePathContainer.get(2).filePath)
+        Assertions.assertEquals("/not.kt", filePathContainer.get(1).filePath)
+        Assertions.assertEquals("/dsa/not.kt", filePathContainer.get(0).filePath)
     }
 
     @Test
@@ -47,7 +47,7 @@ class ExcludeTest {
         val filePaths = listOf("src/main.kt", "src/asd/main.kt", "src/asd/asd.kt", "src/not/asd.kt")
         val filePathContainer = testUtil.setUpProjectFileIndex(filePaths, listOf("/asd*"))
         Assertions.assertEquals(2, filePathContainer.size())
-        Assertions.assertEquals("/not/asd.kt", filePathContainer.get(0).string)
+        Assertions.assertEquals("/not/asd.kt", filePathContainer.get(0).filePath)
     }
 
     @Test
@@ -55,6 +55,6 @@ class ExcludeTest {
         val filePaths = listOf("src/main.log", "src/asd/main.log", "src/asd/asd.kt", "src/not/asd.kt", "src/nope")
         val filePathContainer = testUtil.setUpProjectFileIndex(filePaths, listOf("*.log"))
         Assertions.assertEquals(3, filePathContainer.size())
-        Assertions.assertEquals("/asd/asd.kt", filePathContainer.get(0).string)
+        Assertions.assertEquals("/asd/asd.kt", filePathContainer.get(0).filePath)
     }
 }

--- a/src/test/kotlin/com/mituuz/fuzzier/FuzzyActionTest.kt
+++ b/src/test/kotlin/com/mituuz/fuzzier/FuzzyActionTest.kt
@@ -6,33 +6,32 @@ import com.intellij.openapi.editor.actionSystem.EditorActionManager
 import com.intellij.openapi.project.Project
 import com.intellij.testFramework.TestApplicationManager
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
-import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
+import com.mituuz.fuzzier.StringEvaluator.FilenameType.*
+import com.mituuz.fuzzier.StringEvaluator.FuzzyMatchContainer
 import com.mituuz.fuzzier.components.SimpleFinderComponent
+import com.mituuz.fuzzier.settings.FuzzierSettingsService
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import java.awt.event.InputEvent
 import java.awt.event.KeyEvent
 import javax.swing.JComponent
+import javax.swing.JLabel
+import javax.swing.JList
 import javax.swing.KeyStroke
 
 class FuzzyActionTest {
     private var testApplicationManager: TestApplicationManager
     private val testUtil: TestUtil = TestUtil()
+    private var settings: FuzzierSettingsService.State
 
     init {
         testApplicationManager = TestApplicationManager.getInstance()
+        settings = FuzzierSettingsService.State()
     }
 
     @Test
     fun `Test custom handlers`() {
-        val action = object : FuzzyAction() {
-            override fun actionPerformed(actionEvent: AnActionEvent) {
-            }
-
-            override fun updateListContents(project: Project, searchString: String) {
-            }
-        }
-
+        val action = getAction()
         val myFixture: CodeInsightTestFixture = testUtil.setUpProject(emptyList())
 
         action.component = SimpleFinderComponent(myFixture.project)
@@ -54,14 +53,7 @@ class FuzzyActionTest {
 
     @Test
     fun `Test custom handlers and reset`() {
-        val action = object : FuzzyAction() {
-            override fun actionPerformed(actionEvent: AnActionEvent) {
-            }
-
-            override fun updateListContents(project: Project, searchString: String) {
-            }
-        }
-
+        val action = getAction()
         val actionManager = EditorActionManager.getInstance()
 
         action.setCustomHandlers()
@@ -71,5 +63,76 @@ class FuzzyActionTest {
         action.resetOriginalHandlers()
         assertFalse(actionManager.getActionHandler(IdeActions.ACTION_EDITOR_MOVE_CARET_DOWN) is FuzzyAction.FuzzyListActionHandler)
         assertFalse(actionManager.getActionHandler(IdeActions.ACTION_EDITOR_MOVE_CARET_UP) is FuzzyAction.FuzzyListActionHandler)
+    }
+
+    @Test
+    fun `Check renderer filename only`() {
+        val action = getAction()
+        action.setFiletype(FILENAME_ONLY)
+        val myFixture: CodeInsightTestFixture = testUtil.setUpProject(emptyList())
+        val project = myFixture.project
+        action.component = SimpleFinderComponent(project)
+        val renderer = action.getCellRenderer()
+        val container = FuzzyMatchContainer(1, "/src/asd", "asd")
+        val dummyList = JList<FuzzyMatchContainer>()
+        val component = renderer.getListCellRendererComponent(dummyList, container, 0, false, false) as JLabel
+        assertNotNull(component)
+        assertEquals("asd", component.text)
+    }
+
+    @Test
+    fun `Check renderer with path`() {
+        val action = getAction()
+        action.setFiletype(FILENAME_WITH_PATH)
+        val myFixture: CodeInsightTestFixture = testUtil.setUpProject(emptyList())
+        val project = myFixture.project
+        action.component = SimpleFinderComponent(project)
+        val renderer = action.getCellRenderer()
+        val container = FuzzyMatchContainer(1, "/src/asd", "asd")
+        val dummyList = JList<FuzzyMatchContainer>()
+        val component = renderer.getListCellRendererComponent(dummyList, container, 0, false, false) as JLabel
+        assertNotNull(component)
+        assertEquals("asd (/src/asd)", component.text)
+    }
+
+    @Test
+    fun `Check renderer full path`() {
+        val action = getAction()
+        action.setFiletype(FILEPATH_ONLY)
+        val myFixture: CodeInsightTestFixture = testUtil.setUpProject(emptyList())
+        val project = myFixture.project
+        action.component = SimpleFinderComponent(project)
+        val renderer = action.getCellRenderer()
+        val container = FuzzyMatchContainer(1, "/src/asd", "asd")
+        val dummyList = JList<FuzzyMatchContainer>()
+        val component = renderer.getListCellRendererComponent(dummyList, container, 0, false, false) as JLabel
+        assertNotNull(component)
+        assertEquals("/src/asd", component.text)
+    }
+
+    @Test
+    fun `Check renderer dir selector`() {
+        val action = getAction()
+        action.setFiletype(FILENAME_ONLY)
+        val myFixture: CodeInsightTestFixture = testUtil.setUpProject(emptyList())
+        val project = myFixture.project
+        action.component = SimpleFinderComponent(project)
+        action.component.isDirSelector = true
+        val renderer = action.getCellRenderer()
+        val container = FuzzyMatchContainer(1, "/src/asd", "asd")
+        val dummyList = JList<FuzzyMatchContainer>()
+        val component = renderer.getListCellRendererComponent(dummyList, container, 0, false, false) as JLabel
+        assertNotNull(component)
+        assertEquals("/src/asd", component.text)
+    }
+
+    private fun getAction(): FuzzyAction {
+        return object : FuzzyAction() {
+            override fun actionPerformed(actionEvent: AnActionEvent) {
+            }
+
+            override fun updateListContents(project: Project, searchString: String) {
+            }
+        }
     }
 }

--- a/src/test/kotlin/com/mituuz/fuzzier/FuzzyMoverTest.kt
+++ b/src/test/kotlin/com/mituuz/fuzzier/FuzzyMoverTest.kt
@@ -1,22 +1,30 @@
 package com.mituuz.fuzzier
 
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.service
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.psi.PsiManager
 import com.intellij.testFramework.TestApplicationManager
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
+import com.mituuz.fuzzier.StringEvaluator.FuzzyMatchContainer
 import com.mituuz.fuzzier.components.SimpleFinderComponent
+import com.mituuz.fuzzier.settings.FuzzierSettingsService
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import javax.swing.JLabel
+import javax.swing.JList
+import javax.swing.SwingUtilities
 
 class FuzzyMoverTest {
     private var fuzzyMover: FuzzyMover
     private var testApplicationManager: TestApplicationManager
     private val testUtil: TestUtil = TestUtil()
+    private var settings: FuzzierSettingsService.State
 
     init {
         testApplicationManager = TestApplicationManager.getInstance()
         fuzzyMover = FuzzyMover()
+        settings  = service<FuzzierSettingsService>().state
     }
 
     @Test
@@ -63,5 +71,62 @@ class FuzzyMoverTest {
                 assertNull(targetFile)
             }.join()
         }
+    }
+
+    @Test
+    fun `Check renderer filename only`() {
+        settings.filenameType = StringEvaluator.FilenameType.FILENAME_ONLY
+        val myFixture: CodeInsightTestFixture = testUtil.setUpProject(emptyList())
+        val project = myFixture.project
+        fuzzyMover.component = SimpleFinderComponent(project)
+        val renderer = fuzzyMover.getCellRenderer()
+        val container = FuzzyMatchContainer(1, "/src/asd", "asd")
+        val dummyList = JList<FuzzyMatchContainer>()
+        val component = renderer.getListCellRendererComponent(dummyList, container, 0, false, false) as JLabel
+        assertNotNull(component)
+        assertEquals("asd", component.text)
+    }
+
+    @Test
+    fun `Check renderer with path`() {
+        settings.filenameType = StringEvaluator.FilenameType.FILENAME_WITH_PATH
+        val myFixture: CodeInsightTestFixture = testUtil.setUpProject(emptyList())
+        val project = myFixture.project
+        fuzzyMover.component = SimpleFinderComponent(project)
+        val renderer = fuzzyMover.getCellRenderer()
+        val container = FuzzyMatchContainer(1, "/src/asd", "asd")
+        val dummyList = JList<FuzzyMatchContainer>()
+        val component = renderer.getListCellRendererComponent(dummyList, container, 0, false, false) as JLabel
+        assertNotNull(component)
+        assertEquals("asd (/src/asd)", component.text)
+    }
+
+    @Test
+    fun `Check renderer full path`() {
+        settings.filenameType = StringEvaluator.FilenameType.FILEPATH_ONLY
+        val myFixture: CodeInsightTestFixture = testUtil.setUpProject(emptyList())
+        val project = myFixture.project
+        fuzzyMover.component = SimpleFinderComponent(project)
+        val renderer = fuzzyMover.getCellRenderer()
+        val container = FuzzyMatchContainer(1, "/src/asd", "asd")
+        val dummyList = JList<FuzzyMatchContainer>()
+        val component = renderer.getListCellRendererComponent(dummyList, container, 0, false, false) as JLabel
+        assertNotNull(component)
+        assertEquals("/src/asd", component.text)
+    }
+
+    @Test
+    fun `Check renderer dir selector`() {
+        settings.filenameType = StringEvaluator.FilenameType.FILENAME_ONLY
+        val myFixture: CodeInsightTestFixture = testUtil.setUpProject(emptyList())
+        val project = myFixture.project
+        fuzzyMover.component = SimpleFinderComponent(project)
+        fuzzyMover.component.isDirSelector = true
+        val renderer = fuzzyMover.getCellRenderer()
+        val container = FuzzyMatchContainer(1, "/src/asd", "asd")
+        val dummyList = JList<FuzzyMatchContainer>()
+        val component = renderer.getListCellRendererComponent(dummyList, container, 0, false, false) as JLabel
+        assertNotNull(component)
+        assertEquals("/src/asd", component.text)
     }
 }

--- a/src/test/kotlin/com/mituuz/fuzzier/FuzzyMoverTest.kt
+++ b/src/test/kotlin/com/mituuz/fuzzier/FuzzyMoverTest.kt
@@ -19,12 +19,10 @@ class FuzzyMoverTest {
     private var fuzzyMover: FuzzyMover
     private var testApplicationManager: TestApplicationManager
     private val testUtil: TestUtil = TestUtil()
-    private var settings: FuzzierSettingsService.State
 
     init {
         testApplicationManager = TestApplicationManager.getInstance()
         fuzzyMover = FuzzyMover()
-        settings  = service<FuzzierSettingsService>().state
     }
 
     @Test
@@ -71,62 +69,5 @@ class FuzzyMoverTest {
                 assertNull(targetFile)
             }.join()
         }
-    }
-
-    @Test
-    fun `Check renderer filename only`() {
-        settings.filenameType = StringEvaluator.FilenameType.FILENAME_ONLY
-        val myFixture: CodeInsightTestFixture = testUtil.setUpProject(emptyList())
-        val project = myFixture.project
-        fuzzyMover.component = SimpleFinderComponent(project)
-        val renderer = fuzzyMover.getCellRenderer()
-        val container = FuzzyMatchContainer(1, "/src/asd", "asd")
-        val dummyList = JList<FuzzyMatchContainer>()
-        val component = renderer.getListCellRendererComponent(dummyList, container, 0, false, false) as JLabel
-        assertNotNull(component)
-        assertEquals("asd", component.text)
-    }
-
-    @Test
-    fun `Check renderer with path`() {
-        settings.filenameType = StringEvaluator.FilenameType.FILENAME_WITH_PATH
-        val myFixture: CodeInsightTestFixture = testUtil.setUpProject(emptyList())
-        val project = myFixture.project
-        fuzzyMover.component = SimpleFinderComponent(project)
-        val renderer = fuzzyMover.getCellRenderer()
-        val container = FuzzyMatchContainer(1, "/src/asd", "asd")
-        val dummyList = JList<FuzzyMatchContainer>()
-        val component = renderer.getListCellRendererComponent(dummyList, container, 0, false, false) as JLabel
-        assertNotNull(component)
-        assertEquals("asd (/src/asd)", component.text)
-    }
-
-    @Test
-    fun `Check renderer full path`() {
-        settings.filenameType = StringEvaluator.FilenameType.FILEPATH_ONLY
-        val myFixture: CodeInsightTestFixture = testUtil.setUpProject(emptyList())
-        val project = myFixture.project
-        fuzzyMover.component = SimpleFinderComponent(project)
-        val renderer = fuzzyMover.getCellRenderer()
-        val container = FuzzyMatchContainer(1, "/src/asd", "asd")
-        val dummyList = JList<FuzzyMatchContainer>()
-        val component = renderer.getListCellRendererComponent(dummyList, container, 0, false, false) as JLabel
-        assertNotNull(component)
-        assertEquals("/src/asd", component.text)
-    }
-
-    @Test
-    fun `Check renderer dir selector`() {
-        settings.filenameType = StringEvaluator.FilenameType.FILENAME_ONLY
-        val myFixture: CodeInsightTestFixture = testUtil.setUpProject(emptyList())
-        val project = myFixture.project
-        fuzzyMover.component = SimpleFinderComponent(project)
-        fuzzyMover.component.isDirSelector = true
-        val renderer = fuzzyMover.getCellRenderer()
-        val container = FuzzyMatchContainer(1, "/src/asd", "asd")
-        val dummyList = JList<FuzzyMatchContainer>()
-        val component = renderer.getListCellRendererComponent(dummyList, container, 0, false, false) as JLabel
-        assertNotNull(component)
-        assertEquals("/src/asd", component.text)
     }
 }

--- a/src/test/kotlin/com/mituuz/fuzzier/FuzzyMoverTest.kt
+++ b/src/test/kotlin/com/mituuz/fuzzier/FuzzyMoverTest.kt
@@ -1,17 +1,13 @@
 package com.mituuz.fuzzier
 
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.vfs.VirtualFileManager
-import com.intellij.psi.PsiDirectory
 import com.intellij.psi.PsiManager
 import com.intellij.testFramework.TestApplicationManager
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
-import com.intellij.testFramework.fixtures.IdeaProjectTestFixture
 import com.mituuz.fuzzier.components.SimpleFinderComponent
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
-import javax.swing.SwingUtilities
 
 class FuzzyMoverTest {
     private var fuzzyMover: FuzzyMover


### PR DESCRIPTION
Add three different ways to render the file list contents:
- Full path
    - Default option
    - Show full file path from root
- Filename only
    - just the file name
    - e.g. from last "/"
- Filename with (path)
    - Filename first with the full path following in brackets