### PR TITLE
Add render limit and html rendering

### DIFF
--- a/src/main/kotlin/com/mituuz/fuzzier/Fuzzier.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/Fuzzier.kt
@@ -88,7 +88,7 @@ open class Fuzzier : FuzzyAction() {
         currentTask?.takeIf { !it.isDone }?.cancel(true)
         currentTask = ApplicationManager.getApplication().executeOnPooledThread {
             component.fileList.setPaintBusy(true)
-            val listModel = DefaultListModel<FuzzyMatchContainer>()
+            var listModel = DefaultListModel<FuzzyMatchContainer>()
             val projectFileIndex = ProjectFileIndex.getInstance(project)
             val projectBasePath = project.basePath
             val stringEvaluator = StringEvaluator(
@@ -101,9 +101,8 @@ open class Fuzzier : FuzzyAction() {
             if (contentIterator != null) {
                 projectFileIndex.iterateContent(contentIterator)
             }
-            val sortedList = listModel.elements().toList().sortedByDescending { it.getScore() }
-            listModel.clear()
-            sortedList.forEach { listModel.addElement(it) }
+
+            listModel = fuzzierUtil.sortAndLimit(listModel)
 
             SwingUtilities.invokeLater {
                 component.fileList.model = listModel

--- a/src/main/kotlin/com/mituuz/fuzzier/FuzzierVCS.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/FuzzierVCS.kt
@@ -25,7 +25,7 @@ class FuzzierVCS : Fuzzier() {
         currentTask?.takeIf { !it.isDone }?.cancel(true)
         currentTask = ApplicationManager.getApplication().executeOnPooledThread {
             component.fileList.setPaintBusy(true)
-            val listModel = DefaultListModel<FuzzyMatchContainer>()
+            var listModel = DefaultListModel<FuzzyMatchContainer>()
             val projectFileIndex = ProjectFileIndex.getInstance(project)
             val changeListManager = ChangeListManager.getInstance(project)
             val projectBasePath = project.basePath
@@ -41,9 +41,8 @@ class FuzzierVCS : Fuzzier() {
             if (contentIterator != null) {
                 projectFileIndex.iterateContent(contentIterator)
             }
-            val sortedList = listModel.elements().toList().sortedByDescending { it.getScore() }
-            listModel.clear()
-            sortedList.forEach { listModel.addElement(it) }
+
+            listModel = fuzzierUtil.sortAndLimit(listModel)
 
             SwingUtilities.invokeLater {
                 component.fileList.model = listModel

--- a/src/main/kotlin/com/mituuz/fuzzier/FuzzyAction.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/FuzzyAction.kt
@@ -18,6 +18,7 @@ import com.mituuz.fuzzier.entities.FuzzyMatchContainer
 import com.mituuz.fuzzier.entities.FuzzyMatchContainer.FilenameType
 import com.mituuz.fuzzier.entities.FuzzyMatchContainer.FilenameType.FILE_PATH_ONLY
 import com.mituuz.fuzzier.settings.FuzzierSettingsService
+import com.mituuz.fuzzier.util.FuzzierUtil
 import java.awt.Component
 import java.awt.event.ActionEvent
 import java.awt.event.InputEvent
@@ -37,6 +38,7 @@ abstract class FuzzyAction : AnAction() {
     protected val fuzzierSettingsService = service<FuzzierSettingsService>()
     @Volatile
     var currentTask: Future<*>? = null
+    val fuzzierUtil = FuzzierUtil()
 
     override fun actionPerformed(actionEvent: AnActionEvent) {
         // Necessary override

--- a/src/main/kotlin/com/mituuz/fuzzier/FuzzyMover.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/FuzzyMover.kt
@@ -178,7 +178,7 @@ class FuzzyMover : FuzzyAction() {
 
         currentTask = ApplicationManager.getApplication().executeOnPooledThread {
             component.fileList.setPaintBusy(true)
-            val listModel = DefaultListModel<FuzzyMatchContainer>()
+            var listModel = DefaultListModel<FuzzyMatchContainer>()
             val projectFileIndex = ProjectFileIndex.getInstance(project)
             val projectBasePath = project.basePath
 
@@ -191,9 +191,8 @@ class FuzzyMover : FuzzyAction() {
             if (contentIterator != null) {
                 projectFileIndex.iterateContent(contentIterator)
             }
-            val sortedList = listModel.elements().toList().sortedByDescending { it.getScore() }
-            listModel.clear()
-            sortedList.forEach { listModel.addElement(it) }
+
+            listModel = fuzzierUtil.sortAndLimit(listModel)
 
             SwingUtilities.invokeLater {
                 component.fileList.model = listModel

--- a/src/main/kotlin/com/mituuz/fuzzier/components/FuzzierSettingsComponent.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/components/FuzzierSettingsComponent.kt
@@ -43,11 +43,27 @@ class FuzzierSettingsComponent {
         """
             Controls how the filename is shown on the file search and selector popups.<br><br>
             Choices are as follows (/path/to/file):<br><br>
-            <strong>Full path</strong> - Shows the full path of the file: /path/to/file<br>
-            <strong>Filename only</strong> - Shows only the filename: file<br>
-            <strong>Filename with (path)</strong> - Shows path in brackets: file (/path/to/file)
-            <strong>Filename with (path) styled</strong> - Uses bold for filename and italic for the path: <strong>file</strong> <i>(path/to/file)</i>
-            This is more performance intensive, you should not use too high file list limit with this option.
+            
+            <strong>Full path</strong> - Shows the full path of the file:
+            <br>
+            /path/to/file
+            
+            <br><br>
+            <strong>Filename only</strong> - Shows only the filename:
+            <br>
+            file
+            
+            <br><br>
+            <strong>Filename with (path)</strong> - Shows path in brackets:
+            <br>
+            file (/path/to/file)
+            
+            <br><br>
+            <strong>Filename with (path) styled</strong> - Uses bold for filename and italic for the path:
+            <br>
+            <strong>file</strong>  <i>(path/to/file)</i>
+            <br>
+            <strong>Note!</strong>This is more performance intensive, you should not use too high file list limit with this option.
     """.trimIndent(),
         false)
 

--- a/src/main/kotlin/com/mituuz/fuzzier/components/FuzzierSettingsComponent.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/components/FuzzierSettingsComponent.kt
@@ -46,7 +46,15 @@ class FuzzierSettingsComponent {
             <strong>Full path</strong> - Shows the full path of the file: /path/to/file<br>
             <strong>Filename only</strong> - Shows only the filename: file<br>
             <strong>Filename with (path)</strong> - Shows path in brackets: file (/path/to/file)
+            <strong>Filename with (path) styled</strong> - Uses bold for filename and italic for the path: <strong>file</strong> <i>(path/to/file)</i>
+            This is more performance intensive, you should not use too high file list limit with this option.
     """.trimIndent(),
+        false)
+
+    val fileListLimit = SettingsComponent(JBIntSpinner(50, 1, 5000), "File list limit",
+        """
+            Controls how many files are shown and listed on the popup.
+        """.trimIndent(),
         false)
 
     val fontSize = SettingsComponent(JBIntSpinner(14, 4, 20), "File list font size",
@@ -119,6 +127,7 @@ class FuzzierSettingsComponent {
             .addComponent(newTabSelect)
             .addComponent(debounceTimerValue)
             .addComponent(filenameTypeSelector)
+            .addComponent(fileListLimit)
             .addComponent(fontSize)
             .addComponent(fileListSpacing)
 

--- a/src/main/kotlin/com/mituuz/fuzzier/entities/FuzzyMatchContainer.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/entities/FuzzyMatchContainer.kt
@@ -1,13 +1,17 @@
 package com.mituuz.fuzzier.entities
 
 class FuzzyMatchContainer(val score: FuzzyScore, var filePath: String, var filename: String) {
-
     fun toString(filenameType: FilenameType): String {
         return when (filenameType) {
             FilenameType.FILENAME_ONLY -> filename
             FilenameType.FILE_PATH_ONLY -> filePath
             FilenameType.FILENAME_WITH_PATH -> "$filename   ($filePath)"
+            FilenameType.FILENAME_WITH_PATH_STYLED -> getFilenameWithPathStyled()
         }
+    }
+
+    private fun getFilenameWithPathStyled(): String {
+        return "<html><strong>$filename</strong>  <i>($filePath)</i></html>"
     }
 
     fun getScore(): Int {
@@ -17,7 +21,8 @@ class FuzzyMatchContainer(val score: FuzzyScore, var filePath: String, var filen
     enum class FilenameType(val text: String) {
         FILE_PATH_ONLY("File path only"),
         FILENAME_ONLY("Filename only"),
-        FILENAME_WITH_PATH("Filename with (path)")
+        FILENAME_WITH_PATH("Filename with (path)"),
+        FILENAME_WITH_PATH_STYLED("Filename with (path) styled")
     }
 
     class FuzzyScore {

--- a/src/main/kotlin/com/mituuz/fuzzier/settings/FuzzierSettingsConfigurable.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/settings/FuzzierSettingsConfigurable.kt
@@ -21,6 +21,7 @@ class FuzzierSettingsConfigurable : Configurable {
         fuzzierSettingsComponent.newTabSelect.getCheckBox().isSelected = fuzzierSettingsService.state.newTab
         fuzzierSettingsComponent.debounceTimerValue.getIntSpinner().value = fuzzierSettingsService.state.debouncePeriod
         fuzzierSettingsComponent.filenameTypeSelector.getFilenameTypeComboBox().selectedIndex = fuzzierSettingsService.state.filenameType.ordinal
+        fuzzierSettingsComponent.fileListLimit.getIntSpinner().value = fuzzierSettingsService.state.fileListLimit
         fuzzierSettingsComponent.fontSize.getIntSpinner().value = fuzzierSettingsService.state.fontSize
         fuzzierSettingsComponent.fileListSpacing.getIntSpinner().value = fuzzierSettingsService.state.fileListSpacing
 
@@ -38,6 +39,7 @@ class FuzzierSettingsConfigurable : Configurable {
                 || fuzzierSettingsService.state.newTab != fuzzierSettingsComponent.newTabSelect.getCheckBox().isSelected
                 || fuzzierSettingsService.state.debouncePeriod != fuzzierSettingsComponent.debounceTimerValue.getIntSpinner().value
                 || fuzzierSettingsService.state.filenameType != fuzzierSettingsComponent.filenameTypeSelector.getFilenameTypeComboBox().selectedItem
+                || fuzzierSettingsService.state.fileListLimit != fuzzierSettingsComponent.fileListLimit.getIntSpinner().value
                 || fuzzierSettingsService.state.fontSize != fuzzierSettingsComponent.fontSize.getIntSpinner().value
                 || fuzzierSettingsService.state.fileListSpacing != fuzzierSettingsComponent.fileListSpacing.getIntSpinner().value
 
@@ -57,6 +59,7 @@ class FuzzierSettingsConfigurable : Configurable {
         fuzzierSettingsService.state.newTab = fuzzierSettingsComponent.newTabSelect.getCheckBox().isSelected
         fuzzierSettingsService.state.debouncePeriod = fuzzierSettingsComponent.debounceTimerValue.getIntSpinner().value as Int
         fuzzierSettingsService.state.filenameType = FilenameType.entries.toTypedArray()[fuzzierSettingsComponent.filenameTypeSelector.getFilenameTypeComboBox().selectedIndex]
+        fuzzierSettingsService.state.fileListLimit = fuzzierSettingsComponent.fileListLimit.getIntSpinner().value as Int
         fuzzierSettingsService.state.fontSize = fuzzierSettingsComponent.fontSize.getIntSpinner().value as Int
         fuzzierSettingsService.state.fileListSpacing = fuzzierSettingsComponent.fileListSpacing.getIntSpinner().value as Int
         

--- a/src/main/kotlin/com/mituuz/fuzzier/settings/FuzzierSettingsService.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/settings/FuzzierSettingsService.kt
@@ -17,11 +17,13 @@ class FuzzierSettingsService : PersistentStateComponent<FuzzierSettingsService.S
         var newTab: Boolean = false
         var debouncePeriod: Int = 150
         var resetWindow = false
-        var multiMatch = false
+        var fileListLimit: Int = 50
+
         var filenameType: FilenameType = FILE_PATH_ONLY
         var fontSize = 14
         var fileListSpacing = 0
 
+        var multiMatch = false
         var matchWeightPartialPath = 10
         var matchWeightSingleChar = 5
         var matchWeightStreakModifier = 10

--- a/src/main/kotlin/com/mituuz/fuzzier/util/FuzzierUtil.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/util/FuzzierUtil.kt
@@ -7,7 +7,7 @@ import java.util.*
 import javax.swing.DefaultListModel
 
 class FuzzierUtil {
-    private val listLimit: Int = service<FuzzierSettingsService>().state.fileListLimit
+    private var listLimit: Int = service<FuzzierSettingsService>().state.fileListLimit
 
     /**
      * Process all the elements in the listModel with a priority queue to limit the size
@@ -35,5 +35,9 @@ class FuzzierUtil {
         result.addAll(priorityQueue.toList().sortedByDescending { it.getScore() })
 
         return result
+    }
+
+    fun setListLimit(limit: Int) {
+        listLimit = limit
     }
 }

--- a/src/main/kotlin/com/mituuz/fuzzier/util/FuzzierUtil.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/util/FuzzierUtil.kt
@@ -32,7 +32,7 @@ class FuzzierUtil {
         }
 
         val result = DefaultListModel<FuzzyMatchContainer>()
-        result.addAll(priorityQueue.toList())
+        result.addAll(priorityQueue.toList().sortedByDescending { it.getScore() })
 
         return result
     }

--- a/src/main/kotlin/com/mituuz/fuzzier/util/FuzzierUtil.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/util/FuzzierUtil.kt
@@ -1,0 +1,39 @@
+package com.mituuz.fuzzier.util
+
+import com.intellij.openapi.components.service
+import com.mituuz.fuzzier.entities.FuzzyMatchContainer
+import com.mituuz.fuzzier.settings.FuzzierSettingsService
+import java.util.*
+import javax.swing.DefaultListModel
+
+class FuzzierUtil {
+    private val listLimit: Int = service<FuzzierSettingsService>().state.fileListLimit
+
+    /**
+     * Process all the elements in the listModel with a priority queue to limit the size
+     * and keeping the data sorted at all times
+     *
+     * Priority queue's size is limit + 1 to prevent any resizing
+     * Only add entries to the queue if they have larger score than the minimum in the queue
+     *
+     * @return a sorted and sized list model
+     */
+    fun sortAndLimit(listModel: DefaultListModel<FuzzyMatchContainer>): DefaultListModel<FuzzyMatchContainer> {
+        val priorityQueue = PriorityQueue(listLimit + 1, compareBy(FuzzyMatchContainer::getScore))
+
+        var minimumScore = -1
+        listModel.elements().toList().forEach {
+            if (it.getScore() > minimumScore) {
+                priorityQueue.add(it)
+                if (priorityQueue.size > listLimit) {
+                    minimumScore = priorityQueue.remove().getScore()
+                }
+            }
+        }
+
+        val result = DefaultListModel<FuzzyMatchContainer>()
+        result.addAll(priorityQueue.toList())
+
+        return result
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -44,8 +44,23 @@
   <br><br>
   It calculates the score based on the longest streak of characters that match the filename.
 
+  <h2>Re-implement html rendering</h2>
+  Add "Filename with (path) styled" as an option to filename type.
+  <br>
+  This uses bold for the filename and italic for the path to make it easier to distinguish between the two.
+  <br><br>
+  e.g. <strong>file</strong>  <i>(path/to/file)</i>
+
+  <h2>Implement file list limit</h2>
+  Add a new setting to limit the number of files shown in the file list.
+  Made a few optimizations to the file list handling and sorting.
+  <br><br>
+  This was necessary to implement the html rendering, because otherwise it would be too slow to render.
+
   <h2>Other changes</h2>
-  Set up automated publishing to marketplace from GitHub when creating a new release tag
+  Set up automated publishing to marketplace from GitHub when creating a new release tag.
+  <br><br>
+  Move documentation to a <a href="https://github.com/MituuZ/fuzzier/wiki" title="Fuzzier Wiki">GitHub Wiki</a>.
   ]]>
   </change-notes>
 

--- a/src/test/kotlin/com/mituuz/fuzzier/FuzzyActionTest.kt
+++ b/src/test/kotlin/com/mituuz/fuzzier/FuzzyActionTest.kt
@@ -87,6 +87,19 @@ class FuzzyActionTest {
     }
 
     @Test
+    fun `Check renderer with styled path`() {
+        val action = getAction()
+        action.setFiletype(FILENAME_WITH_PATH_STYLED)
+        action.component = SimpleFinderComponent()
+        val renderer = action.getCellRenderer()
+        val container = FuzzyMatchContainer(FuzzyScore(), "/src/asd", "asd")
+        val dummyList = JList<FuzzyMatchContainer>()
+        val component = renderer.getListCellRendererComponent(dummyList, container, 0, false, false) as JLabel
+        assertNotNull(component)
+        assertEquals("<html><strong>asd</strong>  <i>(/src/asd)</i></html>", component.text)
+    }
+
+    @Test
     fun `Check renderer full path`() {
         val action = getAction()
         action.setFiletype(FILE_PATH_ONLY)

--- a/src/test/kotlin/com/mituuz/fuzzier/util/FuzzierUtilTest.kt
+++ b/src/test/kotlin/com/mituuz/fuzzier/util/FuzzierUtilTest.kt
@@ -1,0 +1,79 @@
+package com.mituuz.fuzzier.util
+
+import com.intellij.testFramework.TestApplicationManager
+import com.mituuz.fuzzier.entities.FuzzyMatchContainer
+import com.mituuz.fuzzier.entities.FuzzyMatchContainer.FuzzyScore
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import javax.swing.DefaultListModel
+
+class FuzzierUtilTest {
+    @Suppress("unused")
+    private val testApplicationManager = TestApplicationManager.getInstance()
+    private val fuzzierUtil = FuzzierUtil()
+    private val listModel = DefaultListModel<FuzzyMatchContainer>()
+    private lateinit var result: DefaultListModel<FuzzyMatchContainer>
+
+    @BeforeEach
+    fun setUp() {
+        listModel.clear()
+    }
+
+    @Test
+    fun `Sort and limit under limit`() {
+        addElement(1, "file1")
+        addElement(2, "file2")
+        addElement(3, "file3")
+
+        runWithLimit(5)
+        assertEquals(3, result.size)
+        assertEquals("file3", result[0].filename)
+        assertEquals("file2", result[1].filename)
+        assertEquals("file1", result[2].filename)
+    }
+
+    @Test
+    fun `Sort and limit equal to limit`() {
+        addElement(1, "file1")
+        addElement(8, "file2")
+        addElement(3, "file3")
+
+        runWithLimit(3)
+        assertEquals(3, result.size)
+        assertEquals("file2", result[0].filename)
+        assertEquals("file3", result[1].filename)
+        assertEquals("file1", result[2].filename)
+    }
+
+    @Test
+    fun `Sort and limit over limit`() {
+        addElement(1, "file1")
+        addElement(8, "file2")
+        addElement(3, "file3")
+        addElement(4, "file4")
+
+        runWithLimit(2)
+        assertEquals(2, result.size)
+        assertEquals("file2", result[0].filename)
+        assertEquals("file4", result[1].filename)
+    }
+
+    @Test
+    fun `Empty list`() {
+        runWithLimit(2)
+        assertEquals(0, result.size)
+    }
+
+    private fun addElement(score: Int, fileName: String) {
+        val fuzzyScore = FuzzyScore()
+        fuzzyScore.streakScore = score
+        val container = FuzzyMatchContainer(fuzzyScore, "", fileName)
+        listModel.addElement(container)
+    }
+
+    private fun runWithLimit(limit: Int) {
+        fuzzierUtil.setListLimit(limit)
+        result = fuzzierUtil.sortAndLimit(listModel)
+    }
+}


### PR DESCRIPTION
Add new setting to limit how many files are listed when the search is executed. Only showing the ones with the highest score.

Add a new filename type: Filename with (path) styled
This uses html rendering to bold the filename and italicize the path.