### PR TITLE
Improve module root path logic

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.mituuz"
-version = "0.22.0"
+version = "0.22.1"
 
 repositories {
   mavenCentral()

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 ## Earlier Versions
 - Prior to version 0.19.0, numerous features and improvements were made, laying the foundation for the current version. This includes initial development, various enhancements, and bug fixes. For detailed history, please refer to commit logs or release notes.
 
-## Version 0.22.0
+## Version 0.22.1
 - Add setting to prioritize shorter file paths for file mover
 - Handle root path "/" separately for file mover
 - Upgrade to gradle 8.7

--- a/src/main/kotlin/com/mituuz/fuzzier/Fuzzier.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/Fuzzier.kt
@@ -103,9 +103,7 @@ open class Fuzzier : FuzzyAction() {
             val state = service<FuzzierSettingsService>().state
             state.modules = HashMap()
             val moduleManager = ModuleManager.getInstance(project)
-            val uniqueModuleRoots = countModuleRoots(moduleManager)
-
-            if (uniqueModuleRoots > 1) {
+            if (fuzzierUtil.hasMultipleUniqueRootPaths(moduleManager)) {
                 processModules(moduleManager, state, stringEvaluator, searchString, listModel)
             } else {
                 processProject(project, state, stringEvaluator, searchString, listModel)
@@ -122,20 +120,6 @@ open class Fuzzier : FuzzyAction() {
                 }
             }
         }
-    }
-
-    private fun countModuleRoots(moduleManager: ModuleManager): Int {
-        val moduleRoots = mutableSetOf<String>()
-        for (module in moduleManager.modules) {
-            val contentRoots = module.rootManager.contentRoots
-            if (contentRoots.isNotEmpty()) {
-                val moduleBasePath = contentRoots[0]?.path
-                if (moduleBasePath != null) {
-                    moduleRoots.add(moduleBasePath)
-                }
-            }
-        }
-        return moduleRoots.size
     }
 
     private fun processModules(moduleManager: ModuleManager, state: FuzzierSettingsService.State,

--- a/src/main/kotlin/com/mituuz/fuzzier/util/FuzzierUtil.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/util/FuzzierUtil.kt
@@ -1,6 +1,8 @@
 package com.mituuz.fuzzier.util
 
 import com.intellij.openapi.components.service
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.project.rootManager
 import com.mituuz.fuzzier.entities.FuzzyMatchContainer
 import com.mituuz.fuzzier.settings.FuzzierSettingsService
 import java.util.*
@@ -53,4 +55,40 @@ class FuzzierUtil {
     fun setPrioritizeShorterDirPaths(prioritizeShortedFilePaths: Boolean) {
         this.prioritizeShorterDirPaths = prioritizeShortedFilePaths;
     }
+
+    /**
+     * Calculate the number of unique root paths in the project by comparing module paths against each other
+     * Handles cases where some modules are nested under a single project root
+     *
+     * @return true if at least one module has a non-compatible root path, false if all paths can be merged
+     */
+    fun hasMultipleUniqueRootPaths(moduleManager: ModuleManager): Boolean {
+        var currentRoot: String? = null
+        for (module in moduleManager.modules) {
+            val contentRoots = module.rootManager.contentRoots
+            if (contentRoots.isEmpty()) {
+                continue
+            }
+            val moduleBasePath = contentRoots[0]?.path ?: continue
+
+            // Initial case, set the first root
+            if (currentRoot == null) {
+                currentRoot = moduleBasePath
+                continue
+            }
+
+            // Check if either root is contained in the other
+            if (currentRoot.contains(moduleBasePath) || moduleBasePath.contains(currentRoot)) {
+                // Update current root if new root is shorter
+                if (moduleBasePath.length < currentRoot.length) {
+                    currentRoot = moduleBasePath
+                }
+            } else {
+                // Root wasn't contained, multiple root paths are present
+                return true
+            }
+        }
+        return false
+    }
+
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -29,7 +29,7 @@
   </extensions>
 
   <change-notes><![CDATA[
-  <h2>Version 0.22.0</h2>
+  <h2>Version 0.22.1</h2>
   - Add setting to prioritize shorter file paths for file mover<br>
   - Handle root path "/" separately for file mover<br>
   - Upgrade to gradle 8.7<br>

--- a/src/test/kotlin/com/mituuz/fuzzier/TestUtil.kt
+++ b/src/test/kotlin/com/mituuz/fuzzier/TestUtil.kt
@@ -85,7 +85,7 @@ class TestUtil {
         return myFixture
     }
 
-    fun setUpMultiModuleProject(module1Files: List<String>, module2Files: List<String>): CodeInsightTestFixture {
+    fun setUpMultiModuleProject(module1Files: List<String>, module2Files: List<String>, customModule2Path: String = "src2"): CodeInsightTestFixture {
         val factory = IdeaTestFixtureFactory.getFixtureFactory()
         val fixtureBuilder = factory.createFixtureBuilder("Test")
         val fixture = fixtureBuilder.fixture
@@ -97,7 +97,7 @@ class TestUtil {
         addFiles(module2Files, myFixture)
 
         val module1Path = myFixture.findFileInTempDir("src1")
-        val module2Path = myFixture.findFileInTempDir("src2")
+        val module2Path = myFixture.findFileInTempDir(customModule2Path)
 
         val module1 = WriteAction.computeAndWait<Module, RuntimeException> {
             ModuleManager.getInstance(project).newModule(module1Path.path, "Empty")

--- a/src/test/kotlin/com/mituuz/fuzzier/util/FuzzierUtilTest.kt
+++ b/src/test/kotlin/com/mituuz/fuzzier/util/FuzzierUtilTest.kt
@@ -1,9 +1,11 @@
 package com.mituuz.fuzzier.util
 
+import com.intellij.openapi.module.ModuleManager
 import com.intellij.testFramework.TestApplicationManager
+import com.mituuz.fuzzier.TestUtil
 import com.mituuz.fuzzier.entities.FuzzyMatchContainer
 import com.mituuz.fuzzier.entities.FuzzyMatchContainer.FuzzyScore
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import javax.swing.DefaultListModel
@@ -108,6 +110,27 @@ class FuzzierUtilTest {
         assertEquals("file2", result[1].filename)
         assertEquals("file4", result[2].filename)
         assertEquals("file3", result[3].filename)
+    }
+
+    @Test
+    fun `Has multiple modules, single module`() {
+        val testUtil = TestUtil()
+        val myFixture = testUtil.setUpProject(listOf("/src"))
+        assertFalse(fuzzierUtil.hasMultipleUniqueRootPaths(ModuleManager.getInstance(myFixture.project)))
+    }
+
+    @Test
+    fun `Has multiple modules, two modules with different paths`() {
+        val testUtil = TestUtil()
+        val myFixture = testUtil.setUpMultiModuleProject(listOf("/src1/file1"), listOf("/src2/file"))
+        assertTrue(fuzzierUtil.hasMultipleUniqueRootPaths(ModuleManager.getInstance(myFixture.project)))
+    }
+
+    @Test
+    fun `Has multiple modules, two modules with same paths`() {
+        val testUtil = TestUtil()
+        val myFixture = testUtil.setUpMultiModuleProject(listOf("/src1/file1"), listOf("/src1/submodule/file"), "src1/submodule")
+        assertFalse(fuzzierUtil.hasMultipleUniqueRootPaths(ModuleManager.getInstance(myFixture.project)))
     }
 
     private fun addElement(score: Int, fileName: String) {


### PR DESCRIPTION
Instead of straight up checking how many modules there are in the project. Count unique module paths and combine similar paths.