### PR TITLE
Re-implement project handling in case no modules are present

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.mituuz"
-version = "0.26.1"
+version = "0.26.2"
 
 repositories {
   mavenCentral()

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,7 @@
 # Changelog
+## Version 0.26.2
+- Re-implement project file handling as a backup if no modules are present
+
 ## Version 0.26.1
 - Update version support to include 242
 

--- a/src/main/kotlin/com/mituuz/fuzzier/Fuzzier.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/Fuzzier.kt
@@ -35,6 +35,7 @@ import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.rootManager
+import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.ui.popup.JBPopup
 import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.openapi.ui.popup.JBPopupListener
@@ -178,7 +179,11 @@ open class Fuzzier : FuzzyAction() {
                 if (task?.isCancelled == true) throw CancellationException()
 
                 val moduleManager = ModuleManager.getInstance(project)
-                processModules(moduleManager, stringEvaluator, searchString, listModel)
+                if (fuzzierSettingsService.state.isProject) {
+                    processProject(project, stringEvaluator, searchString, listModel)
+                } else {
+                    processModules(moduleManager, stringEvaluator, searchString, listModel)
+                }
 
                 if (task?.isCancelled == true) throw CancellationException()
 
@@ -198,6 +203,12 @@ open class Fuzzier : FuzzyAction() {
                 // Do nothing
             }
         }
+    }
+    
+    private fun processProject(project: Project, stringEvaluator: StringEvaluator,
+                               searchString: String, listModel: DefaultListModel<FuzzyMatchContainer>) {
+        val contentIterator = stringEvaluator.getContentIterator(project.name, searchString, listModel)
+        ProjectFileIndex.getInstance(project).iterateContent(contentIterator)
     }
 
     private fun processModules(moduleManager: ModuleManager, stringEvaluator: StringEvaluator,

--- a/src/main/kotlin/com/mituuz/fuzzier/settings/FuzzierSettingsService.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/settings/FuzzierSettingsService.kt
@@ -37,6 +37,7 @@ import com.mituuz.fuzzier.settings.FuzzierSettingsService.RecentFilesMode.RECENT
 class FuzzierSettingsService : PersistentStateComponent<FuzzierSettingsService.State> {
     class State {
         var modules: Map<String, String> = HashMap()
+        var isProject = false
         var recentFilesMode: RecentFilesMode = RECENT_PROJECT_FILES
 
         var splitPosition: Int = 300

--- a/src/main/kotlin/com/mituuz/fuzzier/util/FuzzierUtil.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/util/FuzzierUtil.kt
@@ -135,6 +135,11 @@ class FuzzierUtil {
             shortenModulePaths(moduleList)
         }
 
+        if (moduleList.isEmpty() && project.basePath != null) {
+            moduleList.add(ModuleContainer(project.name, project.basePath!!))
+            service<FuzzierSettingsService>().state.isProject = true
+        }
+
         val moduleMap = listToMap(moduleList)
         service<FuzzierSettingsService>().state.modules = moduleMap
     }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -29,8 +29,8 @@
   </extensions>
 
   <change-notes><![CDATA[
-  <h2>Version 0.26.1</h2>
-  - Update version support to include 242
+  <h2>Version 0.26.2</h2>
+  - Re-implement project file handling as a backup if no modules are present
   ]]>
   </change-notes>
 


### PR DESCRIPTION
While checking out a Rider issue, I noticed that my projects did not have any modules which prevented Fuzzier from working at all.

This PR re-implements the old project handling in case module count is zero, while still relying on the new module style implementation.