### PR TITLE
Mitigate InterruptException

### DIFF
--- a/src/main/kotlin/com/mituuz/fuzzier/Fuzzier.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/Fuzzier.kt
@@ -205,9 +205,10 @@ open class Fuzzier : FuzzyAction() {
                     }
                 }
             } catch (e: InterruptedException) {
+                Thread.currentThread().interrupt()
                 throw CancellationException()
             } catch (e: CancellationException) {
-                // Do nothing
+                // Do nothing, because each task starts over with a clean listModel
             }
         }
     }

--- a/src/main/kotlin/com/mituuz/fuzzier/Fuzzier.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/Fuzzier.kt
@@ -176,7 +176,6 @@ open class Fuzzier : FuzzyAction() {
                 val stringEvaluator = StringEvaluator(
                     fuzzierSettingsService.state.exclusionSet,
                     fuzzierSettingsService.state.modules,
-                    changeListManager,
                     changeListManager?.ignoredFilePaths
                 )
 

--- a/src/main/kotlin/com/mituuz/fuzzier/Fuzzier.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/Fuzzier.kt
@@ -246,6 +246,7 @@ open class Fuzzier : FuzzyAction() {
             if (!event.valueIsAdjusting) {
                 if (component.fileList.isEmpty) {
                     ApplicationManager.getApplication().invokeLater {
+                        // This can throw slow operation on ETD (previewPane.updateFile)
                         defaultDoc?.let { (component as FuzzyFinderComponent).previewPane.updateFile(it) }
                     }
                     return@addListSelectionListener

--- a/src/main/kotlin/com/mituuz/fuzzier/Fuzzier.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/Fuzzier.kt
@@ -179,7 +179,8 @@ open class Fuzzier : FuzzyAction() {
                 val stringEvaluator = StringEvaluator(
                     fuzzierSettingsService.state.exclusionSet,
                     fuzzierSettingsService.state.modules,
-                    changeListManager
+                    changeListManager,
+                    changeListManager?.ignoredFilePaths
                 )
 
                 if (task?.isCancelled == true) throw CancellationException()

--- a/src/main/kotlin/com/mituuz/fuzzier/Fuzzier.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/Fuzzier.kt
@@ -35,6 +35,7 @@ import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.rootManager
+import com.intellij.openapi.roots.ModuleFileIndex
 import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.ui.popup.JBPopup
 import com.intellij.openapi.ui.popup.JBPopupFactory
@@ -49,6 +50,10 @@ import com.jetbrains.rd.util.ConcurrentHashMap
 import com.mituuz.fuzzier.components.FuzzyFinderComponent
 import com.mituuz.fuzzier.entities.FuzzyMatchContainer
 import com.mituuz.fuzzier.settings.FuzzierSettingsService.RecentFilesMode.NONE
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
 import org.apache.commons.lang3.StringUtils
 import java.awt.event.*
 import javax.swing.*
@@ -218,7 +223,8 @@ open class Fuzzier : FuzzyAction() {
                                searchString: String, listModel: DefaultListModel<FuzzyMatchContainer>) {
         val filesToIterate = ConcurrentHashMap.newKeySet<IterationFile>()
         for (module in moduleManager.modules) {
-            val moduleFileIndex = module.rootManager.fileIndex
+            // This could be a method
+            val moduleFileIndex: ModuleFileIndex = module.rootManager.fileIndex
             moduleFileIndex.iterateContent { file ->
                 if (!file.isDirectory) {
                     filesToIterate.add(IterationFile(file, module.name))

--- a/src/main/kotlin/com/mituuz/fuzzier/Fuzzier.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/Fuzzier.kt
@@ -35,7 +35,6 @@ import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.rootManager
-import com.intellij.openapi.roots.ModuleFileIndex
 import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.ui.popup.JBPopup
 import com.intellij.openapi.ui.popup.JBPopupFactory
@@ -217,7 +216,6 @@ open class Fuzzier : FuzzyAction() {
                                searchString: String, listModel: DefaultListModel<FuzzyMatchContainer>) {
         val filesToIterate = ConcurrentHashMap.newKeySet<FuzzierUtil.IterationFile>()
         FuzzierUtil.fileIndexToIterationFiles(filesToIterate, ProjectFileIndex.getInstance(project), project.name)
-        
         processFiles(filesToIterate, stringEvaluator, listModel, searchString)
     }
 
@@ -227,7 +225,6 @@ open class Fuzzier : FuzzyAction() {
         for (module in moduleManager.modules) {
             FuzzierUtil.fileIndexToIterationFiles(filesToIterate, module.rootManager.fileIndex, module.name)
         }
-        
         processFiles(filesToIterate, stringEvaluator, listModel, searchString)
     }
     

--- a/src/main/kotlin/com/mituuz/fuzzier/Fuzzier.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/Fuzzier.kt
@@ -204,6 +204,8 @@ open class Fuzzier : FuzzyAction() {
                         component.fileList.setSelectedValue(listModel[0], true)
                     }
                 }
+            } catch (e: InterruptedException) {
+                throw CancellationException()
             } catch (e: CancellationException) {
                 // Do nothing
             }

--- a/src/main/kotlin/com/mituuz/fuzzier/Fuzzier.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/Fuzzier.kt
@@ -50,10 +50,7 @@ import com.jetbrains.rd.util.ConcurrentHashMap
 import com.mituuz.fuzzier.components.FuzzyFinderComponent
 import com.mituuz.fuzzier.entities.FuzzyMatchContainer
 import com.mituuz.fuzzier.settings.FuzzierSettingsService.RecentFilesMode.NONE
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.async
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
 import org.apache.commons.lang3.StringUtils
 import java.awt.event.*
 import javax.swing.*
@@ -234,8 +231,14 @@ open class Fuzzier : FuzzyAction() {
             }
         }
         
-        filesToIterate.forEach { iterationFile ->
-            stringEvaluator.processFile(iterationFile, listModel, searchString)
+        runBlocking {
+            withContext(Dispatchers.IO) {
+                filesToIterate.forEach { iterationFile ->
+                    launch {
+                        stringEvaluator.processFile(iterationFile, listModel, searchString)
+                    }
+                }
+            }
         }
     }
 

--- a/src/main/kotlin/com/mituuz/fuzzier/Fuzzier.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/Fuzzier.kt
@@ -213,7 +213,7 @@ open class Fuzzier : FuzzyAction() {
     private fun processProject(project: Project, stringEvaluator: StringEvaluator,
                                searchString: String, listModel: DefaultListModel<FuzzyMatchContainer>) {
         val filesToIterate = ConcurrentHashMap.newKeySet<FuzzierUtil.IterationFile>()
-        FuzzierUtil().fileIndexToIterationFiles(filesToIterate, ProjectFileIndex.getInstance(project), project.name)
+        FuzzierUtil.fileIndexToIterationFiles(filesToIterate, ProjectFileIndex.getInstance(project), project.name)
         
         processFiles(filesToIterate, stringEvaluator, listModel, searchString)
     }
@@ -222,7 +222,7 @@ open class Fuzzier : FuzzyAction() {
                                searchString: String, listModel: DefaultListModel<FuzzyMatchContainer>) {
         val filesToIterate = ConcurrentHashMap.newKeySet<FuzzierUtil.IterationFile>()
         for (module in moduleManager.modules) {
-            FuzzierUtil().fileIndexToIterationFiles(filesToIterate, module.rootManager.fileIndex, module.name)
+            FuzzierUtil.fileIndexToIterationFiles(filesToIterate, module.rootManager.fileIndex, module.name)
         }
         
         processFiles(filesToIterate, stringEvaluator, listModel, searchString)

--- a/src/main/kotlin/com/mituuz/fuzzier/StringEvaluator.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/StringEvaluator.kt
@@ -24,6 +24,8 @@ SOFTWARE.
 package com.mituuz.fuzzier
 
 import com.intellij.openapi.roots.ContentIterator
+import com.intellij.openapi.vcs.FilePath
+import com.intellij.openapi.vcs.LocalFilePath
 import com.intellij.openapi.vcs.changes.ChangeListManager
 import com.intellij.openapi.vfs.VirtualFile
 import com.mituuz.fuzzier.entities.FuzzyMatchContainer
@@ -38,7 +40,8 @@ import javax.swing.DefaultListModel
 class StringEvaluator(
     private var exclusionList: Set<String>,
     private var modules: Map<String, String>,
-    private var changeListManager: ChangeListManager? = null
+    private var changeListManager: ChangeListManager? = null,
+    private var vcsPathContainer: List<FilePath>? = null
 ) {
     lateinit var scoreCalculator: ScoreCalculator
 
@@ -129,8 +132,9 @@ class StringEvaluator(
      * @return true if file should be excluded
      */
     private fun isExcluded(file: VirtualFile, filePath: String): Boolean {
-        if (changeListManager !== null) {
-            return changeListManager!!.isIgnoredFile(file)
+        if (!vcsPathContainer.isNullOrEmpty()) {
+            val fp = LocalFilePath(file.path, false)
+            return vcsPathContainer!!.contains(fp)
         }
         return exclusionList.any { e ->
             when {

--- a/src/main/kotlin/com/mituuz/fuzzier/StringEvaluator.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/StringEvaluator.kt
@@ -62,6 +62,27 @@ class StringEvaluator(
             true
         }
     }
+    
+    fun processFile(iterationFile: Fuzzier.IterationFile, listModel: DefaultListModel<FuzzyMatchContainer>,
+                    searchString: String) {
+        scoreCalculator = ScoreCalculator(searchString)
+        val file = iterationFile.file
+        val moduleName = iterationFile.module
+        if (!file.isDirectory) {
+            val moduleBasePath = modules[moduleName] ?: return
+
+            val filePath = file.path.removePrefix(moduleBasePath)
+            if (isExcluded(file, filePath)) {
+                return
+            }
+            if (filePath.isNotBlank()) {
+                val fuzzyMatchContainer = createFuzzyContainer(filePath, moduleName)
+                if (fuzzyMatchContainer != null) {
+                    listModel.addElement(fuzzyMatchContainer)
+                }
+            }
+        }
+    }
 
     fun getDirIterator(moduleName: String, searchString: String, listModel: DefaultListModel<FuzzyMatchContainer>): ContentIterator {
         scoreCalculator = ScoreCalculator(searchString)

--- a/src/main/kotlin/com/mituuz/fuzzier/StringEvaluator.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/StringEvaluator.kt
@@ -43,10 +43,10 @@ class StringEvaluator(
     private var changeListManager: ChangeListManager? = null,
     private var vcsPathContainer: List<FilePath>? = null
 ) {
-    lateinit var scoreCalculator: ScoreCalculator
+    lateinit var calculator: ScoreCalculator
 
     fun getContentIterator(moduleName: String, searchString: String, listModel: DefaultListModel<FuzzyMatchContainer>): ContentIterator {
-        scoreCalculator = ScoreCalculator(searchString)
+        val scoreCalculator = ScoreCalculator(searchString)
         return ContentIterator { file: VirtualFile ->
             if (!file.isDirectory) {
                 val moduleBasePath = modules[moduleName] ?: return@ContentIterator true
@@ -56,7 +56,7 @@ class StringEvaluator(
                     return@ContentIterator true
                 }
                 if (filePath.isNotBlank()) {
-                    val fuzzyMatchContainer = createFuzzyContainer(filePath, moduleName)
+                    val fuzzyMatchContainer = createFuzzyContainer(filePath, moduleName, scoreCalculator)
                     if (fuzzyMatchContainer != null) {
                         listModel.addElement(fuzzyMatchContainer)
                     }
@@ -68,7 +68,7 @@ class StringEvaluator(
     
     fun processFile(iterationFile: Fuzzier.IterationFile, listModel: DefaultListModel<FuzzyMatchContainer>,
                     searchString: String) {
-        scoreCalculator = ScoreCalculator(searchString)
+        val scoreCalculator = ScoreCalculator(searchString)
         val file = iterationFile.file
         val moduleName = iterationFile.module
         if (!file.isDirectory) {
@@ -79,7 +79,7 @@ class StringEvaluator(
                 return
             }
             if (filePath.isNotBlank()) {
-                val fuzzyMatchContainer = createFuzzyContainer(filePath, moduleName)
+                val fuzzyMatchContainer = createFuzzyContainer(filePath, moduleName, scoreCalculator)
                 if (fuzzyMatchContainer != null) {
                     listModel.addElement(fuzzyMatchContainer)
                 }
@@ -88,7 +88,7 @@ class StringEvaluator(
     }
 
     fun getDirIterator(moduleName: String, searchString: String, listModel: DefaultListModel<FuzzyMatchContainer>): ContentIterator {
-        scoreCalculator = ScoreCalculator(searchString)
+        val scoreCalculator = ScoreCalculator(searchString)
         return ContentIterator { file: VirtualFile ->
             if (file.isDirectory) {
                 val moduleBasePath = modules[moduleName] ?: return@ContentIterator true
@@ -97,7 +97,7 @@ class StringEvaluator(
                     return@ContentIterator true
                 }
                 if (filePath.isNotBlank()) {
-                    val fuzzyMatchContainer = createFuzzyContainer(filePath, moduleName)
+                    val fuzzyMatchContainer = createFuzzyContainer(filePath, moduleName, scoreCalculator)
                     if (fuzzyMatchContainer != null) {
                         listModel.addElement(fuzzyMatchContainer)
                     }
@@ -149,7 +149,7 @@ class StringEvaluator(
      * @param filePath to evaluate
      * @return null if no match can be found
      */
-    private fun createFuzzyContainer(filePath: String, module: String): FuzzyMatchContainer? {
+    private fun createFuzzyContainer(filePath: String, module: String, scoreCalculator: ScoreCalculator): FuzzyMatchContainer? {
         val filename = filePath.substring(filePath.lastIndexOf("/") + 1)
         return when (val score = scoreCalculator.calculateScore(filePath)) {
             null -> {

--- a/src/main/kotlin/com/mituuz/fuzzier/StringEvaluator.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/StringEvaluator.kt
@@ -30,6 +30,7 @@ import com.intellij.openapi.vcs.changes.ChangeListManager
 import com.intellij.openapi.vfs.VirtualFile
 import com.mituuz.fuzzier.entities.FuzzyMatchContainer
 import com.mituuz.fuzzier.entities.ScoreCalculator
+import com.mituuz.fuzzier.util.FuzzierUtil
 import javax.swing.DefaultListModel
 
 /**
@@ -66,7 +67,7 @@ class StringEvaluator(
         }
     }
     
-    fun processFile(iterationFile: Fuzzier.IterationFile, listModel: DefaultListModel<FuzzyMatchContainer>,
+    fun processFile(iterationFile: FuzzierUtil.IterationFile, listModel: DefaultListModel<FuzzyMatchContainer>,
                     searchString: String) {
         val scoreCalculator = ScoreCalculator(searchString)
         val file = iterationFile.file

--- a/src/main/kotlin/com/mituuz/fuzzier/StringEvaluator.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/StringEvaluator.kt
@@ -35,19 +35,22 @@ import javax.swing.DefaultListModel
 
 /**
  * Handles creating the content iterators used for string handling and excluding files
- * @param exclusionList exclusion list from settings
- * @param changeListManager handles VCS check if file is being tracked. Null if VCS search should not be used
+ * @param exclusionList Exclusion list from settings
+ * @param vcsPathContainer Handles the VCS check; if a file is being tracked. Null if VCS search should not be used
  */
 class StringEvaluator(
     private var exclusionList: Set<String>,
     private var modules: Map<String, String>,
-    private var changeListManager: ChangeListManager? = null,
     private var vcsPathContainer: List<FilePath>? = null
 ) {
-    lateinit var calculator: ScoreCalculator
+    // Used for testing and test bench
+    var calculator: ScoreCalculator? = null
 
     fun getContentIterator(moduleName: String, searchString: String, listModel: DefaultListModel<FuzzyMatchContainer>): ContentIterator {
-        val scoreCalculator = ScoreCalculator(searchString)
+        var scoreCalculator = ScoreCalculator(searchString)
+        if (calculator is ScoreCalculator) {
+            scoreCalculator = calculator as ScoreCalculator
+        }
         return ContentIterator { file: VirtualFile ->
             if (!file.isDirectory) {
                 val moduleBasePath = modules[moduleName] ?: return@ContentIterator true

--- a/src/main/kotlin/com/mituuz/fuzzier/components/TestBenchComponent.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/components/TestBenchComponent.kt
@@ -168,7 +168,7 @@ class TestBenchComponent : JPanel() {
                                searchString: String, listModel: DefaultListModel<FuzzyMatchContainer>) {
         val contentIterator = stringEvaluator.getContentIterator(project.name, searchString, listModel)
 
-        val scoreCalculator = stringEvaluator.scoreCalculator
+        val scoreCalculator = stringEvaluator.calculator
         scoreCalculator.setMultiMatch(liveSettingsComponent.multiMatchActive.getCheckBox().isSelected)
         scoreCalculator.setMatchWeightSingleChar(liveSettingsComponent.matchWeightSingleChar.getIntSpinner().value as Int)
         scoreCalculator.setMatchWeightStreakModifier(liveSettingsComponent.matchWeightStreakModifier.getIntSpinner().value as Int)
@@ -183,7 +183,7 @@ class TestBenchComponent : JPanel() {
             val moduleFileIndex = module.rootManager.fileIndex
             val contentIterator = stringEvaluator.getContentIterator(module.name, searchString, listModel)
 
-            val scoreCalculator = stringEvaluator.scoreCalculator
+            val scoreCalculator = stringEvaluator.calculator
             scoreCalculator.setMultiMatch(liveSettingsComponent.multiMatchActive.getCheckBox().isSelected)
             scoreCalculator.setMatchWeightSingleChar(liveSettingsComponent.matchWeightSingleChar.getIntSpinner().value as Int)
             scoreCalculator.setMatchWeightStreakModifier(liveSettingsComponent.matchWeightStreakModifier.getIntSpinner().value as Int)

--- a/src/main/kotlin/com/mituuz/fuzzier/components/TestBenchComponent.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/components/TestBenchComponent.kt
@@ -169,11 +169,11 @@ class TestBenchComponent : JPanel() {
         val contentIterator = stringEvaluator.getContentIterator(project.name, searchString, listModel)
 
         val scoreCalculator = stringEvaluator.calculator
-        scoreCalculator.setMultiMatch(liveSettingsComponent.multiMatchActive.getCheckBox().isSelected)
-        scoreCalculator.setMatchWeightSingleChar(liveSettingsComponent.matchWeightSingleChar.getIntSpinner().value as Int)
-        scoreCalculator.setMatchWeightStreakModifier(liveSettingsComponent.matchWeightStreakModifier.getIntSpinner().value as Int)
-        scoreCalculator.setMatchWeightPartialPath(liveSettingsComponent.matchWeightPartialPath.getIntSpinner().value as Int)
-        scoreCalculator.setFilenameMatchWeight(liveSettingsComponent.matchWeightFilename.getIntSpinner().value as Int)
+        scoreCalculator?.setMultiMatch(liveSettingsComponent.multiMatchActive.getCheckBox().isSelected)
+        scoreCalculator?.setMatchWeightSingleChar(liveSettingsComponent.matchWeightSingleChar.getIntSpinner().value as Int)
+        scoreCalculator?.setMatchWeightStreakModifier(liveSettingsComponent.matchWeightStreakModifier.getIntSpinner().value as Int)
+        scoreCalculator?.setMatchWeightPartialPath(liveSettingsComponent.matchWeightPartialPath.getIntSpinner().value as Int)
+        scoreCalculator?.setFilenameMatchWeight(liveSettingsComponent.matchWeightFilename.getIntSpinner().value as Int)
         ProjectFileIndex.getInstance(project).iterateContent(contentIterator)
     }
 
@@ -184,11 +184,11 @@ class TestBenchComponent : JPanel() {
             val contentIterator = stringEvaluator.getContentIterator(module.name, searchString, listModel)
 
             val scoreCalculator = stringEvaluator.calculator
-            scoreCalculator.setMultiMatch(liveSettingsComponent.multiMatchActive.getCheckBox().isSelected)
-            scoreCalculator.setMatchWeightSingleChar(liveSettingsComponent.matchWeightSingleChar.getIntSpinner().value as Int)
-            scoreCalculator.setMatchWeightStreakModifier(liveSettingsComponent.matchWeightStreakModifier.getIntSpinner().value as Int)
-            scoreCalculator.setMatchWeightPartialPath(liveSettingsComponent.matchWeightPartialPath.getIntSpinner().value as Int)
-            scoreCalculator.setFilenameMatchWeight(liveSettingsComponent.matchWeightFilename.getIntSpinner().value as Int)
+            scoreCalculator?.setMultiMatch(liveSettingsComponent.multiMatchActive.getCheckBox().isSelected)
+            scoreCalculator?.setMatchWeightSingleChar(liveSettingsComponent.matchWeightSingleChar.getIntSpinner().value as Int)
+            scoreCalculator?.setMatchWeightStreakModifier(liveSettingsComponent.matchWeightStreakModifier.getIntSpinner().value as Int)
+            scoreCalculator?.setMatchWeightPartialPath(liveSettingsComponent.matchWeightPartialPath.getIntSpinner().value as Int)
+            scoreCalculator?.setFilenameMatchWeight(liveSettingsComponent.matchWeightFilename.getIntSpinner().value as Int)
 
             moduleFileIndex.iterateContent(contentIterator)
         }

--- a/src/main/kotlin/com/mituuz/fuzzier/util/FuzzierUtil.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/util/FuzzierUtil.kt
@@ -33,11 +33,27 @@ import java.util.*
 import javax.swing.DefaultListModel
 import kotlin.collections.ArrayList
 import com.intellij.openapi.module.Module
+import com.intellij.openapi.roots.FileIndex
+import com.intellij.openapi.vfs.VirtualFile
+import com.mituuz.fuzzier.Fuzzier
+import java.util.concurrent.ConcurrentHashMap
 
 class FuzzierUtil {
     private var settingsState = service<FuzzierSettingsService>().state
     private var listLimit: Int = settingsState.fileListLimit
     private var prioritizeShorterDirPaths = settingsState.prioritizeShorterDirPaths
+
+    data class IterationFile(val file: VirtualFile, val module: String)
+    
+    companion object fun fileIndexToIterationFiles(iterationFiles: ConcurrentHashMap.KeySetView<IterationFile, Boolean>, 
+                                  fileIndex: FileIndex, moduleName: String) {
+        fileIndex.iterateContent { file ->
+            if (!file.isDirectory) {
+                iterationFiles.add(IterationFile(file, moduleName))
+            }
+            true
+        }
+    }
 
     /**
      * Process all the elements in the listModel with a priority queue to limit the size

--- a/src/main/kotlin/com/mituuz/fuzzier/util/FuzzierUtil.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/util/FuzzierUtil.kt
@@ -35,7 +35,6 @@ import kotlin.collections.ArrayList
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.roots.FileIndex
 import com.intellij.openapi.vfs.VirtualFile
-import com.mituuz.fuzzier.Fuzzier
 import java.util.concurrent.ConcurrentHashMap
 
 class FuzzierUtil {

--- a/src/main/kotlin/com/mituuz/fuzzier/util/FuzzierUtil.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/util/FuzzierUtil.kt
@@ -45,13 +45,15 @@ class FuzzierUtil {
 
     data class IterationFile(val file: VirtualFile, val module: String)
     
-    companion object fun fileIndexToIterationFiles(iterationFiles: ConcurrentHashMap.KeySetView<IterationFile, Boolean>, 
+    companion object {
+        fun fileIndexToIterationFiles(iterationFiles: ConcurrentHashMap.KeySetView<IterationFile, Boolean>, 
                                   fileIndex: FileIndex, moduleName: String) {
-        fileIndex.iterateContent { file ->
-            if (!file.isDirectory) {
-                iterationFiles.add(IterationFile(file, moduleName))
+            fileIndex.iterateContent { file ->
+                if (!file.isDirectory) {
+                    iterationFiles.add(IterationFile(file, moduleName))
+                }
+                true
             }
-            true
         }
     }
 


### PR DESCRIPTION
To avoid getting interrupted the iterable files and ignored file paths can be collected before processing the files.

This should greatly reduce the chance of getting interrupted, because the actual processing is done on the collected lists.