### PR TITLE
fix: use processHandler's waitFor instead of relying on Process'

### DIFF
--- a/src/main/kotlin/com/mituuz/fuzzier/FuzzyGrep.kt
+++ b/src/main/kotlin/com/mituuz/fuzzier/FuzzyGrep.kt
@@ -218,7 +218,7 @@ open class FuzzyGrep() : FuzzyAction() {
                 }
             })
             processHandler.startNotify()
-            processHandler.process.waitFor(2, TimeUnit.SECONDS)
+            processHandler.waitFor(2000)
             output.toString()
         } catch (_: IOException) {
             null


### PR DESCRIPTION
Change the `waitFor` from the process' to the process handler's.

Behavior in Linux machine 

https://github.com/user-attachments/assets/888624d9-5965-46ec-b69e-a110cd9b7bcb

Behavior in Mac machine

https://github.com/user-attachments/assets/cf04b226-61cc-4644-8cb6-1a72d546fc99

Fixes #113  